### PR TITLE
2-3 [배포] [배포] docker, github workflows 이용한 dev 서버 배포 자동화

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -55,6 +55,6 @@ jobs:
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-frontend
             docker stop $(docker ps -a -q)
             docker rm $(docker ps -a -q)
-            docker run -d -p 3001:3001 ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-backend
-            docker run -d -p 80:80 ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-frontend
+            docker run -d -p 4000:4000 ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-backend
+            docker run -d -p 3000:80 ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-frontend
             docker image prune -f

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,0 +1,60 @@
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  push_to_registry:
+    name: Push to ncp container registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to NCP Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.NCP_CONTAINER_REGISTRY }}
+          username: ${{ secrets.NCP_ACCESS_KEY }}
+          password: ${{ secrets.NCP_SECRET_KEY }}
+      - name: BE - build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-backend:latest
+          secrets: |
+            GIT_AUTH_TOKEN=${{ secrets.GIT_TOKEN }}
+
+      - name: FE - build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-frontend:latest
+          secrets: |
+            GIT_AUTH_TOKEN=${{ secrets.GIT_TOKEN }}
+
+  pull_from_registry:
+    name: Connect server ssh and pull from container registry
+    needs: push_to_registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: connect ssh
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DEV_HOST }}
+          username: ${{ secrets.DEV_USERNAME }}
+          password: ${{ secrets.DEV_PASSWORD }}
+          port: ${{ secrets.DEV_PORT }}
+          script: |
+            docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-backend
+            docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-frontend
+            docker stop $(docker ps -a -q)
+            docker rm $(docker ps -a -q)
+            docker run -d -p 3001:3001 ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-backend
+            docker run -d -p 80:80 ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-frontend
+            docker image prune -f

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -55,6 +55,6 @@ jobs:
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-frontend
             docker stop $(docker ps -a -q)
             docker rm $(docker ps -a -q)
-            docker run -d -p 4000:4000 ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-backend
-            docker run -d -p 3000:80 ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-frontend
+            docker run -d -p 4000:4000 --env-file ${{ secrets.ENV_FILENAME_BACKEND }} ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-backend
+            docker run -d -p 3000:80 --env-file ${{ secrets.ENV_FILENAME_FRONTEND }} ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-frontend
             docker image prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.secrets

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .secrets
+.czrc

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:18
-WORKDIR /viewpoint/server
+WORKDIR /app
 COPY package.json .
 RUN npm i
 COPY . .
-CMD npm start:prod
+RUN npm run build
+CMD npm run start:prod

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,2 +1,2 @@
 node_modules
-dist
+build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,13 +1,14 @@
-FROM nginx
+FROM node:18 as builder
 WORKDIR /app
-
-COPY ./package.json .
+COPY package.json .
 RUN npm i
 COPY . .
 RUN npm run build
-COPY ./dist ./dist
 
+FROM nginx:alpine
+WORKDIR /usr/share/nginx/statics
 RUN rm /etc/nginx/conf.d/default.conf
 COPY ./nginx.conf /etc/nginx/conf.d
+COPY --from=builder /app/build .
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,7 +1,7 @@
 server {
     listen 80;
     location / {
-        root    /app;
+        root    /usr/share/nginx/statics;
         index   index.html;
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## 개요
* URL
  * FE: http://49.50.172.204
  * BE: http://49.50.172.204:3001

### 자동화 흐름
1. dev 브랜치 push(또는 pr merge)
2. `deploy_dev.yml` 에서 작성된 job들이 실행됨.
  * Naver Container Registry에 도커 이미지 push 
    * BE build, push
    * FE build, push
  * ssh로 dev용 서버에 접속, Naver Container Registry로부터 FE, BE 이미지 각각 pull & run
> production 용 자동화를 만들려면, 접속할 ssh 서버를 FE/BE 각각 두면 됨.
## 작업사항
* Repository 내의 Secret 설정
### BE
* 현재는 nest 프로젝트의 build만 진행
  * 추후 dockerfile의 수정이 필요함 (redis, db 등 연결 필요)
### FE
* react-script로 build 한 내용을 nginx에서 static 하게 제공

## 리뷰 요청사항
- Dockerfile 및 `deploy_dev.yml`에서 jobs의 흐름

> 이 PR merge 이전에 프론트 쪽 package.json 업데이트 된 내용이 먼저 merge 되어야합니다.