### PR TITLE
2-4 [배포] [배포] docker-compose redis, db 연결

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -55,6 +55,6 @@ jobs:
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-frontend
             docker stop $(docker ps -a -q)
             docker rm $(docker ps -a -q)
-            docker run -d -p 4000:4000 --env-file ${{ secrets.ENV_FILENAME_BACKEND }} ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-backend
+            docker compose --env-file ${{ secrets.ENV_FILENAME_BACKEND}} up --build -d
             docker run -d -p 3000:80 --env-file ${{ secrets.ENV_FILENAME_FRONTEND }} ${{ secrets.NCP_CONTAINER_REGISTRY }}/prv-frontend
             docker image prune -f

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -35,4 +35,4 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 # env
-/.dev.env
+*.env

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3'
+
+services:
+  prv:
+    restart: always
+    env_file:
+      - ${ENV_FILE}
+    image: ${NCP_CONTAINER_REGISTRY}
+    links:
+      - redis
+      - mongo
+    ports:
+      - 4000:4000
+    networks:
+      - viewpoint
+
+  mongo:
+    image: mongo
+    ports:
+      - 27017:27017
+    networks:
+      - viewpoint
+
+  redis:
+    image: redis
+    ports:
+      - 6379:6379
+    networks:
+      - viewpoint
+
+networks:
+  viewpoint:
+    driver: bridge

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,77 +1,78 @@
 {
-  "name": "backend",
-  "version": "0.0.1",
-  "description": "",
-  "author": "",
-  "private": true,
-  "license": "UNLICENSED",
-  "scripts": {
-    "prebuild": "rimraf dist",
-    "build": "nest build",
-    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "nest start",
-    "start:dev": "nest start --watch",
-    "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
-  },
-  "dependencies": {
-    "@liaoliaots/nestjs-redis": "^9.0.4",
-    "@nestjs/common": "^9.0.0",
-    "@nestjs/config": "^2.2.0",
-    "@nestjs/core": "^9.0.0",
-    "@nestjs/platform-express": "^9.0.0",
-    "cache-manager": "^5.1.3",
-    "class-transformer": "^0.5.1",
-    "class-validator": "^0.13.2",
-    "ioredis": "^5.2.4",
-    "reflect-metadata": "^0.1.13",
-    "rimraf": "^3.0.2",
-    "rxjs": "^7.2.0"
-  },
-  "devDependencies": {
-    "@nestjs/cli": "^9.0.0",
-    "@nestjs/schematics": "^9.0.0",
-    "@nestjs/testing": "^9.0.0",
-    "@types/express": "^4.17.13",
-    "@types/jest": "28.1.8",
-    "@types/node": "^16.0.0",
-    "@types/supertest": "^2.0.11",
-    "@typescript-eslint/eslint-plugin": "^5.0.0",
-    "@typescript-eslint/parser": "^5.0.0",
-    "eslint": "^8.0.1",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-prettier": "^4.0.0",
-    "jest": "28.1.3",
-    "prettier": "^2.3.2",
-    "source-map-support": "^0.5.20",
-    "supertest": "^6.1.3",
-    "ts-jest": "28.0.8",
-    "ts-loader": "^9.2.3",
-    "ts-node": "^10.0.0",
-    "tsconfig-paths": "4.1.0",
-    "typescript": "^4.7.4"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
-  }
+	"name": "backend",
+	"version": "0.0.1",
+	"description": "",
+	"author": "",
+	"private": true,
+	"license": "UNLICENSED",
+	"scripts": {
+		"prebuild": "rimraf dist",
+		"build": "nest build",
+		"format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+		"start": "nest start",
+		"start:mac": "env $(cat be.env | grep -v '#' | xargs) npm start",
+		"start:dev": "nest start --watch",
+		"start:debug": "nest start --debug --watch",
+		"start:prod": "node dist/main",
+		"lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+		"test": "jest",
+		"test:watch": "jest --watch",
+		"test:cov": "jest --coverage",
+		"test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+		"test:e2e": "jest --config ./test/jest-e2e.json"
+	},
+	"dependencies": {
+		"@liaoliaots/nestjs-redis": "^9.0.4",
+		"@nestjs/common": "^9.0.0",
+		"@nestjs/config": "^2.2.0",
+		"@nestjs/core": "^9.0.0",
+		"@nestjs/platform-express": "^9.0.0",
+		"cache-manager": "^5.1.3",
+		"class-transformer": "^0.5.1",
+		"class-validator": "^0.13.2",
+		"ioredis": "^5.2.4",
+		"reflect-metadata": "^0.1.13",
+		"rimraf": "^3.0.2",
+		"rxjs": "^7.2.0"
+	},
+	"devDependencies": {
+		"@nestjs/cli": "^9.0.0",
+		"@nestjs/schematics": "^9.0.0",
+		"@nestjs/testing": "^9.0.0",
+		"@types/express": "^4.17.13",
+		"@types/jest": "28.1.8",
+		"@types/node": "^16.0.0",
+		"@types/supertest": "^2.0.11",
+		"@typescript-eslint/eslint-plugin": "^5.0.0",
+		"@typescript-eslint/parser": "^5.0.0",
+		"eslint": "^8.0.1",
+		"eslint-config-prettier": "^8.3.0",
+		"eslint-plugin-prettier": "^4.0.0",
+		"jest": "28.1.3",
+		"prettier": "^2.3.2",
+		"source-map-support": "^0.5.20",
+		"supertest": "^6.1.3",
+		"ts-jest": "28.0.8",
+		"ts-loader": "^9.2.3",
+		"ts-node": "^10.0.0",
+		"tsconfig-paths": "4.1.0",
+		"typescript": "^4.7.4"
+	},
+	"jest": {
+		"moduleFileExtensions": [
+			"js",
+			"json",
+			"ts"
+		],
+		"rootDir": "src",
+		"testRegex": ".*\\.spec\\.ts$",
+		"transform": {
+			"^.+\\.(t|j)s$": "ts-jest"
+		},
+		"collectCoverageFrom": [
+			"**/*.(t|j)s"
+		],
+		"coverageDirectory": "../coverage",
+		"testEnvironment": "node"
+	}
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,6 +5,6 @@ import { AppModule } from './app.module';
 async function bootstrap() {
 	const app = await NestFactory.create(AppModule);
 	app.useGlobalPipes(new ValidationPipe());
-	await app.listen(4000);
+	await app.listen(process.env.PORT);
 }
 bootstrap();


### PR DESCRIPTION
## 개요
Dockerfile 1개만 사용한다면, backend의 dockerfile 내부에는 redis도 있고, mongodb도 있고, api server도 있어야하는 상황이 되었습니다.
따라서, docker-compose로 각 서비스를 `viewpoint` 네트워크로 묶었습니다.

## 작업사항
- ssh-action에서 backend 배포시 docker-compose 사용하도록 변경
- 서버에서 사용할 docker-compose 파일을 작성했습니다.

## 리뷰 요청사항
- 배포 상태 확인
