### PR TITLE
Redis password 설정

### DIFF
--- a/backend/src/ranking/ranking.module.ts
+++ b/backend/src/ranking/ranking.module.ts
@@ -10,6 +10,7 @@ import { ConfigModule } from '@nestjs/config';
       config: {
         host: process.env.REDIS_HOST,
         port: parseInt(process.env.REDIS_PORT, 10) || 6379,
+        password: process.env.REDIS_PASSWORD,
       },
     }),
   ],

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,6 +27,7 @@ services:
       - 6379:6379
     networks:
       - viewpoint
+    command: redis-server --save 60 1000 --loglevel notice --requirepass ${REDIS_PASSWORD}
 
   client:
     image: ${NCP_CONTAINER_REGISTRY}/prv-frontend


### PR DESCRIPTION
## 개요
redis가 외부로부터 flush-all을 당하고 해커가 원하는 값이 redis에 세팅 되는 현상을 발견하여 redis에 비밀번호 설정

* 세팅해놨던 키들이 지속적으로 삭제(flush-all)되는 현상을 발견
* Redis log를 확인하니, DB가 save되는 시점에 flush-all 되는 현상을 확인
* Redis container에서 `keys *` 를 실행해보니, backup1, backup2, backup3, backup4 가 cron 명령어 형태로 세팅됨
  * `dump.rdb` 파일을 확인했을 때, 설정하지 않은 key들이 설정되어있음을 확인
* redis에 비밀번호를 설정해놓지 않아 해킹당했다는 여러 글들을 확인하면서 원인을 파악함.
  * [참고1](https://gofnrk.tistory.com/122)
  * [참고2](https://www.crowdstrike.com/blog/new-kiss-a-dog-cryptojacking-campaign-targets-docker-and-kubernetes/)

### 원인
* Server 생성시 이전 프로젝트 때 생성해놨던 ACG를 그대로 사용하면서 redis에 사용하고 있던 포트가 public하게 열려있는 상태임을 인지하지 못한 상태였음.
* Redis에 비밀번호를 설정해놓지 않아서 누구나 REDIS_PORT만 알면 redis에 접속 가능한 상태였음.

## 작업사항
- #17 fix
* Redis 비밀번호 설정 및 nest application에서 redis 연결시 환경변수로 비밀번호 전달
* Redis의 60초마다 1000개의 key가 변경되었는지 검사하여 save(dump) 함.
* Redis의 loglevel은 기본(notice)으로 함.
  * loglevel 종류
  ```
  # debug (a lot of information, useful for development/testing)
  # verbose (many rarely useful info, but not a mess like the debug level)
  # notice (moderately verbose, what you want in production probably)
  # warning (only very important / critical messages are logged)
  ```
## 리뷰 요청사항
- 백엔드 로컬 개발환경의 `env` 파일에 `REDIS_PASSWORD`를 추가했을 때, application이 정상작동하는가
- 배포된 환경의 redis에 비밀번호를 입력해야만 접속할 수 있는가
