### PR TITLE
 2-6 [배포] [fix] checkout step 추가

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   changes:
+    name: Diff check
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -14,6 +15,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:


### PR DESCRIPTION
## 개요
`https://github.com/dorny/paths-filter` 에서 [`actions/checkout` step이 필요없다고 이야기한 부분](https://github.com/dorny/paths-filter#conditional-execution)은 `on - pull request` 일 때 입니다.
현재 자동 배포에 사용하고 있는 action은 `on - push` 일 때여서, 해당 스텝이 필요했으나, #39 에서 누락하였습니다.

## 작업사항
- `actions/checkout` step 추가
- private repo에서 해당 액션 테스트

## 리뷰 요청사항
- 자동 배포가 정상적으로 작동하기 위해서는 이 PR이 우선적으로 merge 되어야합니다.
