### PR TITLE
2-6 [배포] [fix] actions 마지막 단계 미실행 현상 해결

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -86,6 +86,9 @@ jobs:
   pull_from_registry:
     name: Connect server ssh and pull from container registry
     needs: [push_to_registry_be, push_to_registry_fe]
+    if: |
+      always() && 
+      (needs.push_to_registry_be.result == 'success' || needs.push_to_registry_fe.result == 'success')
     runs-on: ubuntu-latest
     steps:
       - name: connect ssh


### PR DESCRIPTION
## 개요
`pull_from_registry`의 실행 순서는 `push_to_registry_be`와 `push_to_registry_fe` 가 모두 실행된 후여야합니다.
하지만, 두 job 중 하나라도 실행되었다면 `pull_from_registry`는 실행되어야합니다.
현재는 backend 폴더와 frontend 폴더가 모두 수정되어야 작동됩니다.

## 작업사항
- #46 으로 인한 배포 자동화 막힘 현상 해결
- PR이 머지된 후에는 아래 사진과 같이, 2단계에서의 2개의 job 중 하나라도 완료되면 서버로 배포를 진행합니다.
![image](https://user-images.githubusercontent.com/25934842/203235536-d9f7017b-6ed3-43e6-b205-3a2aa47b9f03.png)

## 리뷰 요청사항
- N/A
