### PR TITLE
4-6 [FE] [메인 - 인기 검색어] 인기검색어 클릭 시 해당 검색어로 검색된 페이지로 이동하고, 검색결과 데이터를 요청하고 받아온다.

### DIFF
--- a/frontend/src/pages/Main/components/KeywordRanking.tsx
+++ b/frontend/src/pages/Main/components/KeywordRanking.tsx
@@ -1,5 +1,10 @@
-import { useEffect, useState } from 'react';
+import { AxiosError } from 'axios';
+import { useState } from 'react';
+import { useQuery } from 'react-query';
+import { createSearchParams, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import Api from '../../../api/api';
+import { PATH_SEARCH_LIST } from '../../../constants/path';
 import DropdownIcon from '../../../icons/DropdownIcon';
 import DropDownReverseIcon from '../../../icons/DropdownReverseIcon';
 import RankingSlide from './RankingSlide';
@@ -9,57 +14,57 @@ interface IRankingData {
   count: number;
 }
 
+const api = new Api();
+
 const KeywordRanking = () => {
   const [isRankingListOpen, setisRankingListOpen] = useState(false);
-  const [rankingData, setRankingData] = useState<IRankingData[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string>();
-  const handleButtonClick = () => {
+  const navigate = useNavigate();
+  const {
+    isLoading,
+    isError,
+    data: rankingData,
+  } = useQuery<IRankingData[], AxiosError>('getKeywordRanking', () => api.getKeywordRanking().then((res) => res.data), {
+    retry: 3,
+  });
+
+  const goToSearchList = (keyword: string) => {
+    const params = { keyword, page: '1', rows: '20' };
+    navigate({
+      pathname: PATH_SEARCH_LIST,
+      search: createSearchParams(params).toString(),
+    });
+  };
+
+  const handleRankingClick = () => {
     setisRankingListOpen((prev) => !prev);
   };
 
-  useEffect(() => {
-    const fetchKeywordRanking = async () => {
-      try {
-        const response = await fetch('http://49.50.172.204:4000/keyword-ranking');
-        if (!response.ok) {
-          throw Error(`Response: ${response.statusText}`);
-        }
-        const data: IRankingData[] = await response.json();
-        setRankingData(data);
-        setIsLoading(true);
-      } catch (err) {
-        let message = 'Unknown Error';
-        if (err instanceof Error) message = err.message;
-        setError(message);
-      }
-    };
-
-    fetchKeywordRanking();
-  }, []);
+  const handleKeywordClick = (keyword: string) => {
+    goToSearchList(keyword);
+  };
 
   return (
     <RankingContainer>
-      {error ? (
-        <div>{error}</div>
+      {isError ? (
+        <ErrorMessage>오류 발생으로 인기검색어 사용이 불가합니다.</ErrorMessage>
       ) : (
         <RankingBar>
           <HeaderContainer>
             <span>인기 검색어</span>
             <HeaderDivideLine />
-            <RankingContent onClick={handleButtonClick}>
-              {isLoading && (rankingData.length ? <RankingSlide rankingData={rankingData} /> : '데이터가 없습니다.')}
+            <RankingContent onClick={handleRankingClick}>
+              {!isLoading && (rankingData?.length ? <RankingSlide rankingData={rankingData} /> : '데이터가 없습니다.')}
             </RankingContent>
-            <DropdownReverseButton type="button" onClick={handleButtonClick}>
+            <DropdownReverseButton type="button" onClick={handleRankingClick}>
               {isRankingListOpen ? <DropDownReverseIcon /> : <DropdownIcon />}
             </DropdownReverseButton>
           </HeaderContainer>
           {isRankingListOpen && (
             <>
               <DivideLine />
-              <RankingKeywordContainer onClick={handleButtonClick}>
-                {rankingData.slice(0, 10).map((data, index) => (
-                  <KeywordContainer key={`${index}${data.keyword}`}>
+              <RankingKeywordContainer>
+                {rankingData?.slice(0, 10).map((data, index) => (
+                  <KeywordContainer key={`${index}${data.keyword}`} onClick={() => handleKeywordClick(data.keyword)}>
                     <KeywordIndex>{index + 1}</KeywordIndex>
                     <Keyword>{data.keyword}</Keyword>
                   </KeywordContainer>
@@ -69,7 +74,7 @@ const KeywordRanking = () => {
           )}
         </RankingBar>
       )}
-      {isRankingListOpen && <Dimmer onClick={handleButtonClick} />}
+      {isRankingListOpen && <Dimmer onClick={handleRankingClick} />}
     </RankingContainer>
   );
 };
@@ -78,6 +83,14 @@ const RankingContainer = styled.div`
   position: relative;
   width: 500px;
   height: 70px;
+`;
+
+const ErrorMessage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 30px;
+  padding: 5px 20px;
 `;
 
 const RankingBar = styled.div`

--- a/frontend/src/pages/Main/components/KeywordRanking.tsx
+++ b/frontend/src/pages/Main/components/KeywordRanking.tsx
@@ -17,7 +17,7 @@ interface IRankingData {
 const api = new Api();
 
 const KeywordRanking = () => {
-  const [isRankingListOpen, setisRankingListOpen] = useState(false);
+  const [isRankingListOpen, setIsRankingListOpen] = useState(false);
   const navigate = useNavigate();
   const {
     isLoading,
@@ -36,7 +36,7 @@ const KeywordRanking = () => {
   };
 
   const handleRankingClick = () => {
-    setisRankingListOpen((prev) => !prev);
+    setIsRankingListOpen((prev) => !prev);
   };
 
   const handleKeywordClick = (keyword: string) => {


### PR DESCRIPTION
## 개요
- 인기검색어 api 호출 로직 react-query로 변경
- 인기검색어 클릭 시 검색 페이지로 이동

## 작업사항
- 인기검색어 api 호출 로직을 react-query로 변경했습니다.
- 인기검색어 클릭 시 해당 키워드로 검색된 페이지로 이동합니다.
- 인기검색어 api 호출에서 오류 발생 시 3번 retry 후 인기검색어 부분에 에러 메시지가 뜨도록 설정했습니다.