### PR TITLE
10-2 [BE] [Fix] query의 default 값 지정

### DIFF
--- a/backend/src/search/pipe/search.dto.ts
+++ b/backend/src/search/pipe/search.dto.ts
@@ -1,17 +1,14 @@
-import { IsNotEmpty, IsInt, IsBoolean } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsOptional, IsPositive } from 'class-validator';
 
 export class SearchDto {
-  // TODO : SearchValidationPipe 거쳐야함
-  // 현재는 crossref query 사용자에 의해 조작 가능
-  @IsNotEmpty()
-  keyword: string;
-
-  @IsInt()
+  @IsOptional()
+  @Transform((params) => parseInt(params.value))
+  @IsPositive()
   rows = 20;
 
-  @IsInt()
+  @IsOptional()
+  @Transform((params) => parseInt(params.value))
+  @IsPositive()
   page = 1;
-
-  @IsBoolean()
-  hasDoi = true;
 }

--- a/backend/src/search/pipe/search.pipe.ts
+++ b/backend/src/search/pipe/search.pipe.ts
@@ -1,14 +1,14 @@
 import { ArgumentMetadata, BadRequestException, PipeTransform } from '@nestjs/common';
 
-export class SearchValidationPipe implements PipeTransform {
+export class KeywordValidationPipe implements PipeTransform {
   transform(value: string, metadata: ArgumentMetadata) {
     if (!this.isKeywordValid(value)) {
-      throw new BadRequestException(`공백으로는 검색할 수 없습니다.`);
+      throw new BadRequestException(`2자 이상으로 검색할 수 있습니다.`);
     }
     return encodeURIComponent(value);
   }
   private isKeywordValid(value: string) {
-    return value && value !== '';
+    return value && value !== '' && value.length > 1;
   }
 }
 

--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -15,7 +15,7 @@ export class SearchService {
     return { items, totalItems };
   }
 
-  async getCrossRefData(keyword: string, rows: number, page: number, isDoiExist: boolean) {
+  async getCrossRefData(keyword: string, rows: number, page: number) {
     const crossRefdata = await this.httpService.axiosRef.get<CrossRefResponse>(
       CROSSREF_API_URL(
         keyword,
@@ -34,7 +34,7 @@ export class SearchService {
       Array(Math.ceil(totalItems / rows))
         .fill(0)
         .map((_, i) => {
-          return this.getCrossRefData(keyword, rows, i + 1, false);
+          return this.getCrossRefData(keyword, rows, i + 1);
         }),
     );
     console.log(totalItems);


### PR DESCRIPTION
## 개요
* client에서 항상 query value를 전달해줘야하는 이슈
* query value가 string으로 처리되는 이슈

## 작업사항
- `SearchDto` 의 validation 로직 수정
- `KeywordValidation` 에서 2글자 이상인 경우 valid 하도록 처리

## 리뷰 요청사항
- N/A
