### PR TITLE
7-7 [FE] [fix] 검색어 단어가 여러개일 때 각 단어 별 강조 기능 추가

### DIFF
--- a/frontend/src/components/AutoCompletedList.tsx
+++ b/frontend/src/components/AutoCompletedList.tsx
@@ -22,11 +22,18 @@ const AutoCompletedList = ({
 
   // keyword 강조
   const highlightKeyword = (text: string) => {
-    const rawKeyword = keyword.trim().toLowerCase();
-    return rawKeyword !== '' && text.toLowerCase().includes(rawKeyword)
+    const rawKeywordList = keyword.trim().toLowerCase().split(/\s/gi);
+
+    return rawKeywordList.length > 0 && rawKeywordList.some((rawKeyword) => text.toLowerCase().includes(rawKeyword))
       ? text
-          .split(new RegExp(`(${rawKeyword})`, 'gi'))
-          .map((part, i) => (part.trim().toLowerCase() === rawKeyword ? <Emphasize key={i}>{part}</Emphasize> : part))
+          .split(new RegExp(`(${rawKeywordList.join('|')})`, 'gi'))
+          .map((part, i) =>
+            rawKeywordList.some((keywordPart) => part.trim().toLowerCase() === keywordPart) ? (
+              <Emphasize key={i}>{part}</Emphasize>
+            ) : (
+              part
+            ),
+          )
       : text;
   };
 


### PR DESCRIPTION
## 개요
자동완성에서 검색어 단어 별로 각각 강조되도록 수정

## 작업사항
- 기존에 전체 키워드와 일치하는 부분만 강조되던 기능을 각 단어 별로 강조되도록 변경했습니다.
<img width="562" alt="image" src="https://user-images.githubusercontent.com/50133823/203500432-674a663b-e41d-4d8c-8646-f6f3bc765eb5.png">

기존 : 'sun star' 전체 부분이 일치해야 강조
변경 : 'sun'과 'star'가 따로 포함되어 있어도 각각 강조

## 리뷰 요청사항
- 로직에서 더 개선할 수 있는 부분이 있을지, 혹시 예외 상황이 있을 지 조언 부탁드립니다.
