### PR TITLE
10-3 [FE][fix] 논문 Title 최대 글자수 설정, 검색결과 Articles 숫자 세자리당 콤마 설정

### DIFF
--- a/frontend/src/components/AutoCompletedList.tsx
+++ b/frontend/src/components/AutoCompletedList.tsx
@@ -1,5 +1,6 @@
 import { Dispatch, SetStateAction, useEffect } from 'react';
 import styled from 'styled-components';
+import { MAX_TITLE_LENGTH } from '../constants/main';
 import { IAutoCompletedItem } from './Search';
 
 interface AutoCompletedListProps {
@@ -8,8 +9,6 @@ interface AutoCompletedListProps {
   hoverdIndex: number;
   setHoveredIndex: Dispatch<SetStateAction<number>>;
 }
-
-const MAX_TITLE_LENGTH = 150;
 
 const AutoCompletedList = ({
   autoCompletedItems = [],

--- a/frontend/src/components/AutoCompletedList.tsx
+++ b/frontend/src/components/AutoCompletedList.tsx
@@ -9,6 +9,8 @@ interface AutoCompletedListProps {
   setHoveredIndex: Dispatch<SetStateAction<number>>;
 }
 
+const MAX_TITLE_LENGTH = 150;
+
 const AutoCompletedList = ({
   autoCompletedItems = [],
   keyword,
@@ -61,7 +63,11 @@ const AutoCompletedList = ({
             onMouseOver={() => setHoveredIndex(i)}
             onMouseDown={() => handleAutoCompletedDown(i)}
           >
-            <Title>{highlightKeyword(item.title)}</Title>
+            <Title>
+              {highlightKeyword(
+                item.title.length > MAX_TITLE_LENGTH ? `${item.title.slice(0, MAX_TITLE_LENGTH)}...` : item.title,
+              )}
+            </Title>
             {item.authors && (
               <Author>
                 authors : {highlightKeyword(getRepresentativeAuthor(item.authors))}

--- a/frontend/src/constants/main.ts
+++ b/frontend/src/constants/main.ts
@@ -1,3 +1,4 @@
 export const TITLE = `Paper Reference Visualization`;
 export const TITLE_KOREAN = `논문간 인용관계 시각화 솔루션`;
 export const SUBTITLE = `This website renders reference relation of paper`;
+export const MAX_TITLE_LENGTH = 150;

--- a/frontend/src/pages/SearchList/components/Paper.tsx
+++ b/frontend/src/pages/SearchList/components/Paper.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { MAX_TITLE_LENGTH } from '../../../constants/main';
 import { IPaper } from '../SearchList';
 
 interface PaperProps {
@@ -30,7 +31,11 @@ const Paper = ({ data, keyword }: PaperProps) => {
 
   return (
     <Container>
-      {title && <Title>{highlightKeyword(title)}</Title>}
+      {title && (
+        <Title>
+          {highlightKeyword(title.length > MAX_TITLE_LENGTH ? `${title.slice(0, MAX_TITLE_LENGTH)}...` : title)}
+        </Title>
+      )}
       {authors && (
         <Content>
           <div>

--- a/frontend/src/pages/SearchList/components/SearchResults.tsx
+++ b/frontend/src/pages/SearchList/components/SearchResults.tsx
@@ -27,7 +27,7 @@ const SearchResults = ({ pageInfo, papers, keyword, page, changePage }: SearchRe
     <>
       {papers.length > 0 ? (
         <>
-          <H1>Articles ({pageInfo.totalItems || 0})</H1>
+          <H1>Articles ({pageInfo.totalItems.toLocaleString() || 0})</H1>
           <Hr />
           <Section>
             <Papers>


### PR DESCRIPTION
## 개요
자동완성 시 논문 제목이 비정상적으로 길면 키워드 highlight 기능에 오류가 발생해서 브라우저가 멈춥니다. (정규표현식 과부하로 추정)
제목이 비정상적으로 긴 경우 유저 사용성도 해칠 수 있기 때문에 제목이 일정 글자수를 넘어가는 경우 예외 처리를 해주었습니다.

검색결과 페이지에서도 키워드 highlight 기능이 사용되기 때문에 동일하게 처리 해주었습니다.

## 작업사항
- 자동완성, 검색결과 페이지 논문 Title 최대 글자 수 설정 (250자)
- 검색결과 페이지 Articles 갯수에 세 자리당 콤마가 찍히도록 설정

## 리뷰 요청사항
- 검색결과 페이지에서 가끔 authors도 비정상적으로 길게 나오는 경우가 있습니다. 이 경우에도 사용성을 해칠 수 있을 것 같아 title과 동일하게 일정 글자수를 넘어가면 ... 처리하거나 자동완성 결과와 같이 '~~ 외 n인' 과 같이 처리하는 게 좋을 것 같습니다. 의견 부탁드립니다.