### PR TITLE
Feature: ranking system 등락 여부 10분마다 업데이트

### DIFF
--- a/backend/src/ranking/ranking.module.ts
+++ b/backend/src/ranking/ranking.module.ts
@@ -3,6 +3,7 @@ import { RedisModule } from '@liaoliaots/nestjs-redis';
 import { RankingController } from './ranking.controller';
 import { RankingService } from './ranking.service';
 import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { ConfigModule } from '@nestjs/config';
         password: process.env.REDIS_PASSWORD,
       },
     }),
+    ScheduleModule.forRoot(),
   ],
   controllers: [RankingController],
   providers: [RankingService],

--- a/backend/src/ranking/ranking.service.ts
+++ b/backend/src/ranking/ranking.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRedis } from '@liaoliaots/nestjs-redis';
 import Redis from 'ioredis';
 import { Ranking } from './entities/ranking.entity';
+import { Interval } from '@nestjs/schedule';
 
 @Injectable()
 export class RankingService {
@@ -11,11 +12,11 @@ export class RankingService {
     const topTen = redisSearchData.slice(0, 10);
     const result: Ranking[] = [];
     await Promise.all(
-      topTen.map(async (v) => {
+      topTen.map(async (v, i) => {
         const tmp: Ranking = { keyword: '', count: 0 };
         tmp.keyword = v;
-        const score = await this.redis.zscore(process.env.REDIS_POPULAR_KEY, v);
-        tmp.count = Number(score);
+        const prevrank = await this.redis.zscore(process.env.REDIS_PREVRANKING, v);
+        prevrank ? (tmp.count = Number(prevrank) - i) : (tmp.count = null);
         result.push(tmp);
       }),
     );
@@ -26,5 +27,16 @@ export class RankingService {
     isRanking
       ? await this.redis.zadd(process.env.REDIS_POPULAR_KEY, Number(isRanking) + 1, data)
       : await this.redis.zadd(process.env.REDIS_POPULAR_KEY, 1, data);
+  }
+  @Interval('update-ranking', 100000)
+  async updateRanking() {
+    const redisSearchData = await this.redis.zrevrangebyscore(process.env.REDIS_POPULAR_KEY, '+inf', 1);
+    const topTen = redisSearchData.slice(0, 100);
+    await this.redis.del(process.env.REDIS_PREVRANKING);
+    await Promise.all(
+      topTen.map(async (v, i) => {
+        await this.redis.zadd(process.env.REDIS_PREVRANKING, i, v);
+      }),
+    );
   }
 }

--- a/backend/src/ranking/ranking.service.ts
+++ b/backend/src/ranking/ranking.service.ts
@@ -28,7 +28,7 @@ export class RankingService {
       ? await this.redis.zadd(process.env.REDIS_POPULAR_KEY, Number(isRanking) + 1, data)
       : await this.redis.zadd(process.env.REDIS_POPULAR_KEY, 1, data);
   }
-  @Interval('update-ranking', 100000)
+  @Interval('update-ranking', 600000)
   async updateRanking() {
     const redisSearchData = await this.redis.zrevrangebyscore(process.env.REDIS_POPULAR_KEY, '+inf', 1);
     const topTen = redisSearchData.slice(0, 100);

--- a/backend/src/search/search.controller.ts
+++ b/backend/src/search/search.controller.ts
@@ -42,10 +42,11 @@ export class SearchController {
   @Interval('notifications', 1000)
   handleInterval() {
     //ToDo 진짜 queue로 변경해야함 리스트에서 shift를 쓰면 최악의 경우 O(n)발생 우선 pop으로 지정
-    if (CROSSREF_CACHE_QUEUE.length == 0) return;
+    if (CROSSREF_CACHE_QUEUE.isEmpty()) return;
     else {
       const url = CROSSREF_CACHE_QUEUE.pop();
       this.searchService.getCacheFromCrossRef(url);
     }
+    console.log(new Array(...CROSSREF_CACHE_QUEUE.data));
   }
 }

--- a/backend/src/util.ts
+++ b/backend/src/util.ts
@@ -2,4 +2,22 @@ export const CROSSREF_API_URL = (keyword: string, rows = 5, selects: string[] = 
   `https://api.crossref.org/works?query=${keyword}&rows=${rows}&select=${selects.join(',')}&offset=${
     rows * (page - 1)
   }`;
-export const CROSSREF_CACHE_QUEUE = [];
+class Queue {
+  data: Set<string>;
+  constructor() {
+    this.data = new Set();
+  }
+  pop() {
+    const firstValue = this.data[Symbol.iterator]().next().value;
+    this.data.delete(firstValue);
+    return firstValue;
+  }
+  push(value: string) {
+    if (!this.data.has(value)) this.data.add(value);
+  }
+  isEmpty() {
+    if (this.data.size == 0) return true;
+    else return false;
+  }
+}
+export const CROSSREF_CACHE_QUEUE = new Queue();


### PR DESCRIPTION
## 개요
현재 ranking system에서 response data 타입이 {keyword: string, count: number} 인데 2번째 인자인 count에 인기검색어의 10분전의 순위 변동을 보여주는 기능입니다.
## 작업사항
- redis에 10분마다 현재 redis의 1~100위까지의 인기검색어를 저장을 하는 Interval작업을 수행합니다.
- REDIS_PREVRANKING 환경 변수가 1~100위까지의 검색어를 저장하는 key값입니다.
- keyword-ranking api 요청을 받으면 현재 redis의 인기검색어에서 10분 전의 1 ~ 100위까지의 인기검색어와 비교하여 등수 변동을 정수로 반환합니다. (음수는 10분전보다 감소등수, 양수는 증가, 0은 유지, null 값은 1~100위 안에 없던 새로운 급등 new 검색어)
- 10분마다 10분전의 1~100위의 데이터를 삭제 후 새롭게 현재 인기검색어 데이터로 업데이트 하는 작업
- 엘라스틱서치 파이프라인 데이터 타입 set을 이용한 queue로 변경

