### PR TITLE
4-6 [FE][fix] 인기검색어 클릭시 검색결과 페이지로 이동하는 방식 수정

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -13,8 +13,8 @@
   "plugins": ["react", "@typescript-eslint", "prettier", "react-hooks"],
   "rules": {
     "react/react-in-jsx-scope": "off",
-    "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
-    "react-hooks/exhaustive-deps": "warn" // Checks effect dependencies
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
   },
   "settings": {
     "import/resolver": {

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -1,3 +1,7 @@
 export const PATH_MAIN = '/';
 export const PATH_SEARCH_LIST = '/search-list';
 export const PATH_DETAIL = '/detail';
+
+export const createSearchQuery = (keyword: string) => {
+  return `${PATH_SEARCH_LIST}?keyword=${keyword}&page=1&rows=20`;
+};

--- a/frontend/src/pages/Main/components/KeywordRanking.tsx
+++ b/frontend/src/pages/Main/components/KeywordRanking.tsx
@@ -1,10 +1,10 @@
 import { AxiosError } from 'axios';
 import { useState } from 'react';
 import { useQuery } from 'react-query';
-import { createSearchParams, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Api from '../../../api/api';
-import { PATH_SEARCH_LIST } from '../../../constants/path';
+import { createSearchQuery } from '../../../constants/path';
 import DropdownIcon from '../../../icons/DropdownIcon';
 import DropDownReverseIcon from '../../../icons/DropdownReverseIcon';
 import RankingSlide from './RankingSlide';
@@ -18,7 +18,6 @@ const api = new Api();
 
 const KeywordRanking = () => {
   const [isRankingListOpen, setIsRankingListOpen] = useState(false);
-  const navigate = useNavigate();
   const {
     isLoading,
     isError,
@@ -27,20 +26,8 @@ const KeywordRanking = () => {
     retry: 3,
   });
 
-  const goToSearchList = (keyword: string) => {
-    const params = { keyword, page: '1', rows: '20' };
-    navigate({
-      pathname: PATH_SEARCH_LIST,
-      search: createSearchParams(params).toString(),
-    });
-  };
-
   const handleRankingClick = () => {
     setIsRankingListOpen((prev) => !prev);
-  };
-
-  const handleKeywordClick = (keyword: string) => {
-    goToSearchList(keyword);
   };
 
   return (
@@ -64,10 +51,12 @@ const KeywordRanking = () => {
               <DivideLine />
               <RankingKeywordContainer>
                 {rankingData?.slice(0, 10).map((data, index) => (
-                  <KeywordContainer key={`${index}${data.keyword}`} onClick={() => handleKeywordClick(data.keyword)}>
-                    <KeywordIndex>{index + 1}</KeywordIndex>
-                    <Keyword>{data.keyword}</Keyword>
-                  </KeywordContainer>
+                  <Link key={data.keyword} to={createSearchQuery(data.keyword)}>
+                    <KeywordContainer>
+                      <KeywordIndex>{index + 1}</KeywordIndex>
+                      <Keyword>{data.keyword}</Keyword>
+                    </KeywordContainer>
+                  </Link>
                 ))}
               </RankingKeywordContainer>
             </>

--- a/frontend/src/style/GlobalStyle.tsx
+++ b/frontend/src/style/GlobalStyle.tsx
@@ -20,6 +20,11 @@ const GlobalStyle = createGlobalStyle`
   li{
     list-style: none;
   }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
## 개요
인기검색어 클릭시 검색결과 페이지로 이동하는 방식을 수정했습니다.
기존 : 각 키워드에 onClick 이벤트를 달고 click 시 `navigate`를 이용하여 페이지 이동
수정 : 각 키워드에 `Link`를 적용하여 페이지 이동

페이지 이동에 react-router-dom을 사용하고 있는데, navigate를 사용하는 것보다 Link 기능을 사용하는 것이 더 직관적으로 페이지 이동을 파악할 수 있고, 코드 양을 줄일 수 있다고 판단하여 수정하였습니다.

## 작업사항
- 인기검색어 클릭시 검색결과 페이지로 이동 로직 navigate -> Link로 변경
- GlobalStyle에서 a 요소 기본 스타일 제거
- .eslint.json 파일 주석 제거

