### PR TITLE
14-3 [FE] [논문 상세 - 네트워크 차트] 검색한 논문과 이를 참조한 논문을 1depth만큼 표현하는 네트워크 그래프를 렌더링 한다.

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,19 +1,19 @@
+import { AxiosError } from 'axios';
+import { Suspense } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { Route, Routes, useLocation } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import { Reset } from 'styled-reset';
+import LoaderWrapper from './components/loader/LoaderWrapper';
 import { PATH_DETAIL, PATH_MAIN, PATH_SEARCH_LIST } from './constants/path';
-import Main from './pages/Main/Main';
-import SearchList from './pages/SearchList/SearchList';
-import PaperDatail from './pages/PaperDetail/PaperDetail';
-import GlobalStyle from './style/GlobalStyle';
-import theme from './style/theme';
-import { AxiosError } from 'axios';
 import ErrorBoundary from './error/ErrorBoundary';
 import GlobalErrorFallback from './error/GlobalErrorFallback';
-import { Suspense } from 'react';
-import LoaderWrapper from './components/loader/LoaderWrapper';
+import Main from './pages/Main/Main';
+import PaperDatail from './pages/PaperDetail/PaperDetail';
+import SearchList from './pages/SearchList/SearchList';
+import GlobalStyle from './style/GlobalStyle';
+import theme from './style/theme';
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/frontend/src/customHooks/useGraphData.ts
+++ b/frontend/src/customHooks/useGraphData.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { IPaperDetail } from '../pages/PaperDetail/PaperDetail';
+
+export default function useGraphData<T>(data: IPaperDetail) {
+  const result = useMemo<T>(() => {
+    const nodes = [
+      { author: data.authors?.[0] || 'unknown', isSelected: true, x: 327, y: 398 },
+      ...data.referenceList.map((v) => ({
+        author: v.author || 'unknown',
+        isSelected: false,
+      })),
+    ];
+    const links = data.referenceList.map((v, i) => ({
+      source: 0,
+      target: i + 1,
+    }));
+
+    return { nodes, links } as T;
+  }, [data]);
+  return result;
+}

--- a/frontend/src/customHooks/useGraphData.ts
+++ b/frontend/src/customHooks/useGraphData.ts
@@ -6,7 +6,7 @@ export default function useGraphData<T>(data: IPaperDetail) {
     const nodes = [
       { author: data.authors?.[0] || 'unknown', isSelected: true, x: 327, y: 398 },
       ...data.referenceList.map((v) => ({
-        author: v.author || 'unknown',
+        author: v.authors?.[0] || 'unknown',
         isSelected: false,
       })),
     ];

--- a/frontend/src/pages/PaperDetail/PaperDetail.tsx
+++ b/frontend/src/pages/PaperDetail/PaperDetail.tsx
@@ -14,7 +14,7 @@ export interface IPaperDetail extends IPaper {
   referenceList: [
     {
       title: string;
-      author: string;
+      authors: string[];
       publishedAt: string;
       citations: number;
       references: number;

--- a/frontend/src/pages/PaperDetail/PaperDetail.tsx
+++ b/frontend/src/pages/PaperDetail/PaperDetail.tsx
@@ -2,13 +2,13 @@ import { useQuery } from 'react-query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Api from '../../api/api';
-import PreviousButtonIcon from '../../icons/PreviousButtonIcon';
+import IconButton from '../../components/IconButton';
+import { PATH_MAIN } from '../../constants/path';
 import LogoIcon from '../../icons/LogoIcon';
+import PreviousButtonIcon from '../../icons/PreviousButtonIcon';
 import { IPaper } from '../SearchList/SearchList';
 import PaperInfo from './components/PaperInfo';
 import ReferenceGraph from './components/ReferenceGraph';
-import { PATH_MAIN } from '../../constants/path';
-import IconButton from '../../components/IconButton';
 
 export interface IPaperDetail extends IPaper {
   referenceList: [
@@ -52,7 +52,7 @@ const PaperDatail = () => {
       {data && (
         <Main>
           <PaperInfo data={data} />
-          <ReferenceGraph />
+          <ReferenceGraph data={data} />
         </Main>
       )}
     </Container>

--- a/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
+++ b/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
@@ -35,7 +35,7 @@ const PaperInfo = ({ data }: IProps) => {
               reference.title && (
                 <ReferenceItem key={index}>
                   <span>{reference.title}</span>
-                  <span>{reference.author}</span>
+                  <span>{reference.authors.join(', ')}</span>
                 </ReferenceItem>
               ),
           )}

--- a/frontend/src/pages/PaperDetail/components/ReferenceGraph.tsx
+++ b/frontend/src/pages/PaperDetail/components/ReferenceGraph.tsx
@@ -1,12 +1,139 @@
+import * as d3 from 'd3';
+import { useEffect, useRef } from 'react';
 import styled from 'styled-components';
+import { IPaperDetail } from '../PaperDetail';
 
-const ReferenceGraph = () => {
-  return <Container></Container>;
+interface ReferenceGraphProps {
+  data: IPaperDetail;
+}
+
+const nodes: any[] = [
+  { name: 'paper' },
+  { name: 'r1' },
+  { name: 'r2' },
+  { name: 'r3' },
+  { name: 'r1-1' },
+  { name: 'r1-2' },
+];
+
+const links: any[] = [
+  { source: 0, target: 1 },
+  { source: 0, target: 2 },
+  { source: 0, target: 3 },
+  { source: 1, target: 4 },
+  { source: 1, target: 5 },
+  { source: 1, target: 5 },
+];
+
+const updateLinks = (linksSelector: SVGGElement) => {
+  d3.select(linksSelector)
+    .selectAll('line')
+    .data(links)
+    .join('line')
+    .attr('x1', (d) => d.source?.x)
+    .attr('y1', (d) => d.source?.y)
+    .attr('x2', (d) => d.target?.x)
+    .attr('y2', (d) => d.target?.y);
+};
+
+const symbolGenerator = d3.symbol().type(d3.symbolStar).size(50);
+const pathData = symbolGenerator();
+
+function updateNodes(nodesSelector: SVGGElement) {
+  d3.select(nodesSelector)
+    .selectAll('path') // -> 빈 selection이라는 객체
+    .data(nodes) // -> 6개 가상의 selection객체 6개 empty node
+    .join('path') // -> selection path element 결정
+    .attr('transform', (d) => `translate(${[d.x, d.y]})`)
+    .attr('d', pathData);
+  d3.select(nodesSelector)
+    .selectAll('text')
+    .data(nodes)
+    .join('text')
+    .text((d) => d.name)
+    .attr('x', (d) => d.x)
+    .attr('y', (d) => d.y)
+    .attr('dy', 5);
+}
+
+const ticked = (linksSelector: SVGGElement, nodesSelector: SVGGElement) => {
+  updateLinks(linksSelector);
+  updateNodes(nodesSelector);
+};
+
+const ReferenceGraph = ({ data }: ReferenceGraphProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const linkRef = useRef<SVGGElement | null>(null);
+  const nodeRef = useRef<SVGGElement | null>(null);
+
+  useEffect(() => {
+    const handleZoom = (e: any) => {
+      d3.select(svgRef.current).selectChildren().attr('transform', e.transform);
+    };
+
+    const zoom = d3.zoom().on('zoom', handleZoom);
+
+    d3.select(svgRef.current as Element).call(zoom);
+
+    d3.forceSimulation(nodes)
+      .force('charge', d3.forceManyBody().strength(-200)) // 척력
+      .force(
+        'center',
+        svgRef?.current && d3.forceCenter(svgRef.current.clientWidth / 2, svgRef.current.clientHeight / 2),
+      )
+      .force('link', d3.forceLink().links(links))
+      .on('tick', () => {
+        if (!linkRef.current || !nodeRef.current) return;
+        ticked(linkRef.current, nodeRef.current);
+      });
+  }, []);
+
+  return (
+    <Container ref={containerRef}>
+      <Graph ref={svgRef}>
+        <Links ref={linkRef}></Links>
+        <Nodes ref={nodeRef}></Nodes>
+      </Graph>
+    </Container>
+  );
 };
 
 const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   flex-grow: 1;
   background-color: ${({ theme }) => theme.COLOR.primary4};
+`;
+
+const Graph = styled.svg`
+  width: 100%;
+  height: 100%;
+`;
+
+const Links = styled.g`
+  line {
+    stroke: #ccc;
+    stroke-dasharray: 1;
+  }
+
+  path {
+    fill: ${({ theme }) => theme.COLOR.secondary1};
+  }
+`;
+
+const Nodes = styled.g`
+  path {
+    fill: ${({ theme }) => theme.COLOR.secondary1};
+  }
+
+  text {
+    text-anchor: middle;
+    font-family: 'Helvetica Neue', Helvetica, sans-serif;
+    fill: #666;
+    font-size: 16px;
+  }
 `;
 
 export default ReferenceGraph;


### PR DESCRIPTION
## 개요
14-3 [FE] [논문 상세 - 네트워크 차트] 검색한 논문과 이를 참조한 논문을 1depth만큼 표현하는 네트워크 그래프를 렌더링 한다.

## 작업사항
- 검색한 논문과 참조한 논문들의 관계를 표현하는 네트워크 그래프를 렌더링 합니다.
- 선택된 노드는 star, 서브노드는 square 모양으로 표시됩니다.
- 스크롤 zooming이 가능합니다.
- 마우스 panning이 가능합니다.
- author를 찾을 수 없는 경우 unknown으로 표시됩니다.

## 리뷰 요청사항
- 데모데이를 앞두고 빠른 작업을 위해 몇가지 타입을 any로 처리한 부분이 있습니다. 이는 추후 수정될 예정입니다.

## 실행화면 
![Dec-01-2022 23-19-46](https://user-images.githubusercontent.com/30085476/205426098-09dd58a2-e365-4555-9e41-a6cd5795036a.gif)