### PR TITLE
13-6 [BE] [Fix] Request batcher 로직 수정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18
 WORKDIR /app
-COPY package.json .
-RUN npm i
+COPY package*.json .
+RUN npm ci
 COPY . .
 RUN npm run build
 CMD npm run start:prod

--- a/backend/src/batch/batch.config.ts
+++ b/backend/src/batch/batch.config.ts
@@ -1,7 +1,8 @@
-export const TIME_INTERVAL = 3 * 1000;
+export const TIME_INTERVAL = 1 * 1000;
+export const RESTART_INTERVAL = 2 * 1000 * 60;
 export const MAX_RETRY = 3;
-export const MAX_DEPTH = 1;
-export const SEARCH_BATCH_SIZE = 10;
-export const DOI_BATCH_SIZE = 40;
+export const MAX_DEPTH = 2;
+export const SEARCH_BATCH_SIZE = 5;
+export const DOI_BATCH_SIZE = 20;
 export const DOI_REGEXP = new RegExp(/^[\d]{2}\.[\d]{1,}\/.*/);
 export const ALLOW_UPDATE = process.env.ALLOW_UPDATE ? (eval(process.env.ALLOW_UPDATE) as boolean) : false;

--- a/backend/src/batch/batch.service.ts
+++ b/backend/src/batch/batch.service.ts
@@ -39,9 +39,6 @@ export class BatchService {
     this.redis.expire(key, 60 * 60 * 24);
     return true;
   }
-  async setDoi(doi: string) {
-    this.doiBatcher.pushToQueue(0, 0, -1, true, doi);
-  }
 
   @Interval(TIME_INTERVAL)
   batchSearchQueue(batchSize = SEARCH_BATCH_SIZE) {

--- a/backend/src/batch/batcher.doi.ts
+++ b/backend/src/batch/batcher.doi.ts
@@ -36,7 +36,7 @@ export class DoiBatcher extends Batcher {
     return { papers: [p], referenceDOIs };
   }
 
-  onRejected(item: QueueItemParsed, params: UrlParams) {
+  onRejected(item: QueueItemParsed, params: UrlParams, shouldPushLeft: boolean) {
     const { doi } = params;
     if (item.retries + 1 > MAX_RETRY) {
       // this.failedQueue.push(item.url);
@@ -44,7 +44,7 @@ export class DoiBatcher extends Batcher {
     }
     console.log('error', item.url);
     item.retries++;
-    this.pushToQueue(item.retries + 1, item.depth, item.pagesLeft - 1, false, doi);
+    this.pushToQueue(item.retries + 1, item.depth, item.pagesLeft - 1, shouldPushLeft, doi);
     return;
   }
 }

--- a/backend/src/batch/batcher.search.ts
+++ b/backend/src/batch/batcher.search.ts
@@ -43,7 +43,7 @@ export class SearchBatcher extends Batcher {
     return { papers, referenceDOIs };
   }
 
-  onRejected(item: QueueItemParsed, params: UrlParams) {
+  onRejected(item: QueueItemParsed, params: UrlParams, shouldPushLeft: boolean) {
     const { keyword, cursor } = params;
     if (item.retries + 1 > MAX_RETRY) {
       // this.failedQueue.push(item.url);
@@ -51,7 +51,7 @@ export class SearchBatcher extends Batcher {
     }
     console.log('error', item.url);
     item.retries++;
-    this.pushToQueue(item.retries + 1, item.depth, item.pagesLeft - 1, false, keyword, cursor);
+    this.pushToQueue(item.retries + 1, item.depth, item.pagesLeft - 1, shouldPushLeft, keyword, cursor);
     return;
   }
 }

--- a/backend/src/search/search.controller.ts
+++ b/backend/src/search/search.controller.ts
@@ -87,7 +87,6 @@ export class SearchController {
       });
       return { ...origin, referenceList };
     }
-    this.batchService.doiBatcher.pushToQueue(0, 1, -1, true, doi);
     throw new NotFoundException('해당 doi는 존재하지 않습니다. 정보를 수집중입니다.');
   }
 

--- a/backend/src/search/search.module.ts
+++ b/backend/src/search/search.module.ts
@@ -10,7 +10,7 @@ import { BatchService } from 'src/batch/batch.service';
 @Module({
   imports: [
     HttpModule.register({
-      timeout: 20000,
+      timeout: 1000 * 60,
       headers: {
         'User-Agent': `Axios/1.1.3(mailto:${process.env.MAIL_TO})`,
       },

--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -123,4 +123,7 @@ export class SearchService {
     });
     return await this.esService.mget<PaperInfoDetail>({ docs });
   }
+  esStat() {
+    return this.esService.cat.indices();
+  }
 }

--- a/backend/src/util.ts
+++ b/backend/src/util.ts
@@ -13,7 +13,7 @@ export const CROSSREF_API_URL_CURSOR = (
 ) =>
   `${BASE_URL}?query=${keyword}&rows=${rows}&select=${selects.join(',')}&mailto=${
     process.env.MAIL_TO
-  }&cursor=${cursor}`;
+  }&sort=is-referenced-by-count&cursor=${cursor}`;
 export const CROSSREF_API_PAPER_URL = (doi: string) => `${BASE_URL}/${doi}`;
 export class Queue<T = string> {
   data: Set<T>;

--- a/backend/src/util.ts
+++ b/backend/src/util.ts
@@ -1,8 +1,8 @@
 const BASE_URL = 'https://api.crossref.org/works';
 export const CROSSREF_API_URL = (keyword: string, rows = 5, page = 1, selects: string[] = ['author', 'title', 'DOI']) =>
-  `${BASE_URL}?query=${keyword}&rows=${rows}&select=${selects.join(',')}&offset=${
-    rows * (page - 1)
-  }&sort=is-referenced-by-count`;
+  `${BASE_URL}?query=${keyword}&rows=${rows}&select=${selects.join(',')}&offset=${rows * (page - 1)}&mailto=${
+    process.env.MAIL_TO
+  }`;
 
 export const MAX_ROWS = 1000;
 export const CROSSREF_API_URL_CURSOR = (
@@ -11,7 +11,9 @@ export const CROSSREF_API_URL_CURSOR = (
   rows = MAX_ROWS,
   selects: string[] = ['title', 'author', 'created', 'is-referenced-by-count', 'references-count', 'DOI', 'reference'],
 ) =>
-  `${BASE_URL}?query=${keyword}&rows=${rows}&select=${selects.join(',')}&sort=is-referenced-by-count&cursor=${cursor}`;
+  `${BASE_URL}?query=${keyword}&rows=${rows}&select=${selects.join(',')}&mailto=${
+    process.env.MAIL_TO
+  }&cursor=${cursor}`;
 export const CROSSREF_API_PAPER_URL = (doi: string) => `${BASE_URL}/${doi}`;
 export class Queue<T = string> {
   data: Set<T>;

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18 as builder
 WORKDIR /app
-COPY package.json .
-RUN npm i
+COPY package*.json .
+RUN npm ci
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
## 개요
1. GitHub Actions Fail 오류 수정
2. Request batcher에 대한 로직을 수정
* 파란 상자 안에 있는 부분이 추가되었습니다.
![image](https://user-images.githubusercontent.com/25934842/205570526-409c417c-7b18-4775-a89a-ba72ccf8f87a.png)
* 키워드로 검색한 논문별로 reference까지 하나씩 탐색하던 로직을 삭제했습니다.
* 사용자로부터 reference에 대한 doi를 직접 검색요청받았을 때, doiQueue에 검색 요청이 들어가며 해당 논문의 reference까지 탐색합니다.
![image](https://user-images.githubusercontent.com/25934842/205570562-a5b12068-de7d-43b7-9d3d-b3fe5af68131.png)


## 작업사항
- `Dockerfile` BE / FE 수정 (npm i -> npm ci) #87
- Too many request를 최대한 방지하기 위해 batch 설정 변경
  - default `TIME_INTERVAL` 을 3초에서 1초로 줄이고, batch 한 단위가 끝나야만 다음 batch를 실행할 수 있도록 함
  - Too many request 발생시, `RESTART_INTERVAL` 만큼 요청을 보내지 않음 (Batcher 내부에 block 변수를 static하게 선언)
  - crossref에 요청을 보낼 때, 1분 정도가 걸릴 때도 있고, 재요청 보냈을 때 요청이 빨리 올 것이라는 기대를 할 수 없어서, axios timeout 시간을 1분으로 변경 (+ sort=is-referenced-by-count 쿼리를 제외해야하나 고민 중 이지만, 해당 keyword에 대해 너무 많은 검색결과가 나올 수 있는 경우, 1개의 키워드에 대한 결과를 수집하는데만 4-5시간 정도 걸릴 것으로 예상되어, 우선 순위가 높은(많이 인용당한) 논문 순으로 우리 DB로 가져오는 것은 필요한 작업이 아닐까하는 생각이 됨)
- redis에 검색했던 keyword를 설정할 때 소문자로 변경하여 저장 / 조회
- `/search/stat`에서 서버의 batch queue 상태와, elasticsearch db 상태를 확인할 수 있음 (debug 용)

## 리뷰 요청사항
- doi로 논문을 조회할 때, 해당 논문의 reference에 대한 정보를 가져오기위해, 총 2번의 get 요청(1. doi에 해당하는 논문 보내줘, 2. referenceList에 있는 논문들의 doi들로 multiGet operation을 만들었으니 여기 해당하는거 다 보내줘)을 elasticsearch에 보냅니다. 이게 [N+1 문제](https://dar0m.tistory.com/213)에 해당할까요?