### PR TITLE
[Fix/pagination]- 검색결과가 없는 경우 404 error내는 오류 수정

### DIFF
--- a/backend/src/ranking/ranking.service.ts
+++ b/backend/src/ranking/ranking.service.ts
@@ -22,7 +22,6 @@ export class RankingService {
     );
     return result;
   }
-  @UsePipes(new ValidationPipe({ transform: true }))
   async insertRedis(data: string) {
     const encodeData = decodeURI(data);
     const isRanking: string = await this.redis.zscore(process.env.REDIS_POPULAR_KEY, encodeData);

--- a/backend/src/search/search.controller.ts
+++ b/backend/src/search/search.controller.ts
@@ -40,7 +40,7 @@ export class SearchController {
     const data = await this.searchService.getElasticSearch(keyword, rows, rows * (page - 1));
     const totalItems = (data.hits.total as SearchTotalHits).value;
     const totalPages = Math.ceil(totalItems / rows);
-    if (page > totalPages) {
+    if (page > totalPages && totalPages !== 0) {
       throw new NotFoundException(`page(${page})는 ${totalPages} 보다 클 수 없습니다.`);
     }
     this.rankingService.insertRedis(keyword);
@@ -48,7 +48,6 @@ export class SearchController {
     if (keywordHasSet) this.batchService.searchBatcher.pushToQueue(0, 0, -1, true, keyword);
 
     const papers = data.hits.hits.map((paper) => new PaperInfoExtended(paper._source));
-    if (papers.length === 0) throw new NotFoundException('검색 결과가 존재하지 않습니다. 정보를 수집중입니다.');
     return {
       papers,
       pageInfo: {


### PR DESCRIPTION
## 개요
https://github.com/boostcampwm-2022/web18-PRV/issues/86
해당 이슈에 관한 수정 사항입니다.
## 작업사항
- search.controller 의 논문의 list의 개수에 따라 예외처리 하는 로직을 살짝 변경하였습니다.
- page가 total page 이상으로 요청하지만, totalpage가 0인 경우는 제외하였습니다.
- 검색결과가 없는경우 throw 404error를 처리 하던 부분을 삭제하고 빈 리스트를 response하여 front측에서 빈 리스트를 처리하도록 다시 변경하였습니다.

