### PR TITLE
7-4 [BE] [Fix] 검색결과 정렬 기준 변경

### DIFF
--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -96,6 +96,7 @@ export class SearchService {
         index: process.env.ELASTIC_INDEX,
         from,
         size,
+        sort: ['_score', { citations: 'desc' }],
         query,
       })
       .catch(() => {


### PR DESCRIPTION
## 개요
정렬 기준에 citations를 추가했습니다.
- 1순위, query에 해당하는 score 내림차순
- 2순위, citations 내림차순

## 작업사항
- `esService.search` 에 `sort` 추가

* [Elasticsearch Docs 참고](https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html)

## 리뷰 요청사항
- N/A
