### PR TITLE
[fix] : autoComplete paper가 없는 경우도 error를 체크하는 오류 수정

### DIFF
--- a/backend/src/search/search.controller.ts
+++ b/backend/src/search/search.controller.ts
@@ -25,7 +25,6 @@ export class SearchController {
     const { keyword } = query;
     const data = await this.searchService.getElasticSearch(keyword);
     const papers = data.hits.hits.map((paper) => new PaperInfo(paper._source));
-    if (papers.length === 0) throw new NotFoundException('검색 결과가 존재하지 않습니다. 정보를 수집중입니다.');
     return papers;
   }
 


### PR DESCRIPTION
## 개요
autocomplete 기능에서도 동일한 404 error 가 발생하여 해당 부분을 제거하였습니다.
## 작업사항
```
    if (papers.length === 0) throw new NotFoundException('검색 결과가 존재하지 않습니다. 정보를 수집중입니다.');
```
해당 코드 삭제, 논문이 존재하지않아도 error가 아니라 빈배열을 그대로 return
