### PR TITLE
[Hotfix] title에 포함된 html tag 제거, author & title 길이제한, 오타수정

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 
 <head>
   <meta charset="utf-8" />

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -11,6 +11,13 @@ const Footer = ({ bgColor, contentColor }: FooterProps) => {
     <Container bgColor={bgColor} contentColor={contentColor}>
       <span>문의사항, 버그제보: vp.prv@gmail.com</span>
       <FooterRight>
+        <DataLink
+          href="https://insidious-abacus-0a9.notion.site/PRV-eb42bf64ddc5435a8f0f939329e0429c"
+          rel="noreferrer"
+          target="_blank"
+        >
+          데이터 수집 정책
+        </DataLink>
         <span>Copyright Ⓒ 2022. View Point All rights reserved.</span>
         <a href="https://github.com/boostcampwm-2022/web18-PRV" rel="noreferrer" target="_blank">
           <GithubLogoIcon />
@@ -19,6 +26,12 @@ const Footer = ({ bgColor, contentColor }: FooterProps) => {
     </Container>
   );
 };
+
+const DataLink = styled.a`
+  :hover {
+    text-decoration: underline;
+  }
+`;
 
 const Container = styled.footer<{ bgColor?: string; contentColor?: string }>`
   display: flex;

--- a/frontend/src/components/search/Search.tsx
+++ b/frontend/src/components/search/Search.tsx
@@ -208,6 +208,7 @@ const Container = styled.div`
   flex: 1;
   overflow-y: auto;
   z-index: 3;
+  margin-bottom: 45px;
   padding-bottom: 15px;
 `;
 

--- a/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
+++ b/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
@@ -1,4 +1,6 @@
 import styled from 'styled-components';
+import { MAX_TITLE_LENGTH } from '../../../constants/main';
+import { removeHtml } from '../../../utils/format';
 import { IPaperDetail } from '../PaperDetail';
 
 interface IProps {
@@ -18,13 +20,17 @@ const PaperInfo = ({ data, hoveredNode, changeHoveredNode }: IProps) => {
     changeHoveredNode('');
   };
 
+  const sliceTitle = (title: string) => {
+    return title.length > MAX_TITLE_LENGTH ? `${title.slice(0, MAX_TITLE_LENGTH)}...` : title;
+  };
+
   return (
     <Container>
       <BasicInfo>
-        <Title>{data?.title}</Title>
+        <Title>{sliceTitle(removeHtml(data?.title))}</Title>
         <InfoContainer>
           <InfoItem>
-            <h3>Authors</h3>
+            <h3>{data?.authors.length > 1 ? 'Authors ' : 'Author '}</h3>
             <span>{data?.authors?.join(', ')}</span>
           </InfoItem>
           <InfoItem>
@@ -101,6 +107,13 @@ const InfoItem = styled.div`
   }
   span {
     ${({ theme }) => theme.TYPO.body2};
+    white-space: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    word-break: keep-all;
   }
 `;
 

--- a/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
+++ b/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { MAX_TITLE_LENGTH } from '../../../constants/main';
-import { removeHtml } from '../../../utils/format';
+import { removeTag } from '../../../utils/format';
 import { IPaperDetail } from '../PaperDetail';
 
 interface IProps {
@@ -27,7 +27,7 @@ const PaperInfo = ({ data, hoveredNode, changeHoveredNode }: IProps) => {
   return (
     <Container>
       <BasicInfo>
-        <Title>{sliceTitle(removeHtml(data?.title))}</Title>
+        <Title>{sliceTitle(removeTag(data?.title))}</Title>
         <InfoContainer>
           <InfoItem>
             <h3>{data?.authors.length > 1 ? 'Authors ' : 'Author '}</h3>

--- a/frontend/src/pages/SearchList/components/Paper.tsx
+++ b/frontend/src/pages/SearchList/components/Paper.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { MAX_TITLE_LENGTH } from '../../../constants/main';
+import { removeHtml } from '../../../utils/format';
 import { IPaper } from '../SearchList';
 
 interface PaperProps {
@@ -29,24 +30,24 @@ const Paper = ({ data, keyword }: PaperProps) => {
       : text;
   };
 
+  const sliceTitle = (title: string) => {
+    return title.length > MAX_TITLE_LENGTH ? `${title.slice(0, MAX_TITLE_LENGTH)}...` : title;
+  };
+
   return (
     <Container>
-      {title && (
-        <Title>
-          {highlightKeyword(title.length > MAX_TITLE_LENGTH ? `${title.slice(0, MAX_TITLE_LENGTH)}...` : title)}
-        </Title>
-      )}
+      {title && <Title>{highlightKeyword(sliceTitle(removeHtml(title)))}</Title>}
       {authors && (
         <Content>
           <div>
-            <Bold>authors </Bold>
-            {highlightKeyword(authors?.join(', '))}
+            <Bold>{authors.length > 1 ? 'Authors ' : 'Author '}</Bold>
+            <span>{highlightKeyword(authors?.join(', '))}</span>
           </div>
         </Content>
       )}
       <Content>
         <div>
-          <Bold>published </Bold>
+          <Bold>Published </Bold>
           {year}
         </div>
         <div>
@@ -80,6 +81,15 @@ const Content = styled.div`
   color: ${({ theme }) => theme.COLOR.gray4};
   display: flex;
   justify-content: space-between;
+  > div > span {
+    white-space: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    word-break: keep-all;
+  }
 `;
 
 const Bold = styled.b`

--- a/frontend/src/pages/SearchList/components/Paper.tsx
+++ b/frontend/src/pages/SearchList/components/Paper.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { MAX_TITLE_LENGTH } from '../../../constants/main';
-import { removeHtml } from '../../../utils/format';
+import { removeTag } from '../../../utils/format';
 import { IPaper } from '../SearchList';
 
 interface PaperProps {
@@ -36,7 +36,7 @@ const Paper = ({ data, keyword }: PaperProps) => {
 
   return (
     <Container>
-      {title && <Title>{highlightKeyword(sliceTitle(removeHtml(title)))}</Title>}
+      {title && <Title>{highlightKeyword(sliceTitle(removeTag(title)))}</Title>}
       {authors && (
         <Content>
           <div>

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,3 +1,3 @@
-export const removeHtml = (text: string) => {
+export const removeTag = (text: string) => {
   return text.replace(/<[^>]*>?/g, ' ');
 };

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,3 @@
+export const removeHtml = (text: string) => {
+  return text.replace(/<[^>]*>?/g, ' ');
+};


### PR DESCRIPTION
## 개요
title에 포함된 html tag 제거, author & title 길이제한, 오타수정

## 작업사항
- title에 포함된 html tag 부분을 space 한칸으로 교체 했습니다.
- paperInfo내에서의 title 길이도 list와 동일한 길이로 제한했습니다.
- authors는 3줄까지만 보여집니다.
- author -> Author(s), published -> Published 로 용어 수정되었습니다.
- lang=en -> lang=ko로 수정했습니다

## 리뷰 요청사항
- N/A

## 실행화면
### 변경전
![image](https://user-images.githubusercontent.com/30085476/206347279-2cc19167-0b94-4ddf-9c5c-2b48344b33ef.png)

![스크린샷 2022-12-08 오후 12 13 44](https://user-images.githubusercontent.com/30085476/206347138-3d0f814c-44ad-43b5-bbdd-4c072c06d206.png)

### 변경후
![image](https://user-images.githubusercontent.com/30085476/206346923-df86a9b5-1603-424c-8b31-07e9db5ac4ff.png)
![스크린샷 2022-12-08 오후 12 11 12](https://user-images.githubusercontent.com/30085476/206346937-502d8048-1b78-4d8e-ac7c-802a67573a24.png)