### PR TITLE
[fix] Frontend api BASE_URL 환경변수 설정

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -14,7 +14,7 @@ export interface IGetPaperDetail {
 }
 
 export default class Api {
-  private readonly baseURL = 'http://49.50.172.204:4000/';
+  private readonly baseURL = process.env.REACT_APP_BASE_URL;
   private readonly instance: AxiosInstance;
 
   constructor() {


### PR DESCRIPTION
## 개요
서버 요청 axios api의 BASE_URL을 환경변수로 설정했습니다.
로컬에 `.env.development.local` 파일, 배포 시 `.env.production` 파일 생성 후 `REACT_APP_BASE_URL=` 환경변수 추가가 필요합니다.

## 작업사항
- 서버 요청 api BASE_URL 환경변수 설정

## 리뷰 요청사항
- N/A
