### PR TITLE
[Refactor] 코드 스플리팅 적용, graph 관련 기능 개선 및 상수 변경

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios';
-import { Suspense } from 'react';
+import React, { Suspense } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { Route, Routes, useLocation } from 'react-router-dom';
@@ -8,12 +8,13 @@ import { Reset } from 'styled-reset';
 import LoaderWrapper from './components/loader/LoaderWrapper';
 import { PATH_DETAIL, PATH_MAIN, PATH_SEARCH_LIST } from './constants/path';
 import ErrorBoundary from './error/ErrorBoundary';
-import GlobalErrorFallback from './error/GlobalErrorFallback';
-import Main from './pages/Main/Main';
-import PaperDatail from './pages/PaperDetail/PaperDetail';
-import SearchList from './pages/SearchList/SearchList';
 import GlobalStyle from './style/GlobalStyle';
 import theme from './style/theme';
+
+const Main = React.lazy(() => import('./pages/Main/Main'));
+const SearchList = React.lazy(() => import('./pages/SearchList/SearchList'));
+const GlobalErrorFallback = React.lazy(() => import('./error/GlobalErrorFallback'));
+const PaperDatail = React.lazy(() => import('./pages/PaperDetail/PaperDetail'));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -46,8 +47,8 @@ function App() {
             <Routes>
               <Route path={PATH_MAIN} element={<Main />} />
               <Route path={PATH_SEARCH_LIST} element={<SearchList />} />
-              <Route path={PATH_DETAIL} element={<PaperDatail />} />
               <Route path={'*'} element={<GlobalErrorFallback />} />
+              <Route path={PATH_DETAIL} element={<PaperDatail />} />
             </Routes>
           </Suspense>
         </ErrorBoundary>

--- a/frontend/src/hooks/graph/useGraphData.ts
+++ b/frontend/src/hooks/graph/useGraphData.ts
@@ -14,7 +14,7 @@ export default function useGraphData<T>(data: IPaperDetail) {
       {
         author: data.authors?.[0] || 'unknown',
         isSelected: true,
-        key: data.key,
+        key: data.key.toLowerCase(),
         doi: data.doi,
         citations: data.citations,
         publishedYear: new Date(data.publishedAt).getFullYear(),
@@ -22,7 +22,7 @@ export default function useGraphData<T>(data: IPaperDetail) {
       ...data.referenceList.map((v) => ({
         author: v.authors?.[0] || 'unknown',
         isSelected: false,
-        key: v.key,
+        key: v.key.toLowerCase(),
         doi: v.doi,
         citations: v.citations,
         publishedYear: v.publishedAt && new Date(v.publishedAt).getFullYear(),
@@ -43,8 +43,8 @@ export default function useGraphData<T>(data: IPaperDetail) {
     nodes.current.forEach((node, i) => doiMap.current.set(node.key, i));
 
     const newLinks = data.referenceList.map((reference) => ({
-      source: data.key,
-      target: reference.key,
+      source: data.key.toLowerCase(),
+      target: reference.key.toLowerCase(),
     }));
     if (newLinks.length > 0) setLinks((prev) => [...prev, ...newLinks]);
   }, [data]);

--- a/frontend/src/hooks/graph/useGraphData.ts
+++ b/frontend/src/hooks/graph/useGraphData.ts
@@ -36,7 +36,9 @@ export default function useGraphData<T>(data: IPaperDetail) {
         return;
       }
       if (foundIndex === newIndex) {
-        nodes.current[foundIndex].isSelected = true;
+        Object.entries(node).forEach(([k, v]) => {
+          nodes.current[foundIndex][k] = v;
+        });
       }
     });
 

--- a/frontend/src/hooks/graph/useNodeUpdate.ts
+++ b/frontend/src/hooks/graph/useNodeUpdate.ts
@@ -17,6 +17,8 @@ export default function useNodeUpdate(
 
       const converToColor = d3.scaleLog([1, 10000], ['white', theme.COLOR.secondary2]).interpolate(d3.interpolateRgb);
 
+      console.log(nodes.map((v) => v.citations));
+
       d3.select(nodesSelector)
         .selectAll('path')
         .data(nodes)

--- a/frontend/src/hooks/graph/useNodeUpdate.ts
+++ b/frontend/src/hooks/graph/useNodeUpdate.ts
@@ -15,7 +15,7 @@ export default function useNodeUpdate(
       const normalSymbol = d3.symbol().type(d3.symbolSquare).size(NORMAL_SYMBOL_SIZE)();
       const starSymbol = d3.symbol().type(d3.symbolStar).size(STAR_SYMBOL_SIZE)();
 
-      const converToColor = d3.scaleLog([1, 10000], ['white', theme.COLOR.secondary2]);
+      const converToColor = d3.scaleLog([1, 10000], ['white', theme.COLOR.secondary2]).interpolate(d3.interpolateRgb);
 
       d3.select(nodesSelector)
         .selectAll('path')

--- a/frontend/src/hooks/graph/useNodeUpdate.ts
+++ b/frontend/src/hooks/graph/useNodeUpdate.ts
@@ -15,9 +15,7 @@ export default function useNodeUpdate(
       const normalSymbol = d3.symbol().type(d3.symbolSquare).size(NORMAL_SYMBOL_SIZE)();
       const starSymbol = d3.symbol().type(d3.symbolStar).size(STAR_SYMBOL_SIZE)();
 
-      const converToColor = d3
-        .scaleLog([1, 10, 1000], ['white', theme.COLOR.secondary1, theme.COLOR.secondary2])
-        .interpolate(d3.interpolateRgb);
+      const converToColor = d3.scaleLog([1, 10000], ['white', theme.COLOR.secondary2]);
 
       d3.select(nodesSelector)
         .selectAll('path')
@@ -26,7 +24,7 @@ export default function useNodeUpdate(
         .attr('transform', (d) => `translate(${[d.x, d.y]})`)
         .attr('d', (d) => (d.isSelected ? starSymbol : normalSymbol))
         .attr('fill', (d) => converToColor(d.citations || 0))
-        .on('click', (_, d) => (d.doi ? addChildrensNodes(d.doi) : undefined));
+        .on('click', (_, d) => d.doi && addChildrensNodes(d.doi));
 
       d3.select(nodesSelector)
         .selectAll('text')

--- a/frontend/src/hooks/graph/useNodeUpdate.ts
+++ b/frontend/src/hooks/graph/useNodeUpdate.ts
@@ -26,6 +26,7 @@ export default function useNodeUpdate(
         .attr('transform', (d) => `translate(${[d.x, d.y]})`)
         .attr('d', (d) => (d.isSelected ? starSymbol : normalSymbol))
         .attr('fill', (d) => converToColor(d.citations || 0))
+        .attr('fill-opacity', (d) => (d.doi ? 1 : 0.5))
         .on('click', (_, d) => d.doi && addChildrensNodes(d.doi));
 
       d3.select(nodesSelector)

--- a/frontend/src/pages/PaperDetail/PaperDetail.tsx
+++ b/frontend/src/pages/PaperDetail/PaperDetail.tsx
@@ -34,7 +34,7 @@ const PaperDatail = () => {
   const [doi, setDoi] = useState<string>(searchParams.get('doi') || '');
   const [hoveredNode, setHoveredNode] = useState('');
   const { isLoading, data: _data } = useQuery<IPaperDetail>(
-    ['paperDetail', doi],
+    ['paperDetail', doi.toLowerCase()],
     () => api.getPaperDetail({ doi }).then((res) => res.data),
     {
       select: (data) => {

--- a/frontend/src/pages/PaperDetail/PaperDetail.tsx
+++ b/frontend/src/pages/PaperDetail/PaperDetail.tsx
@@ -30,7 +30,7 @@ const PaperDatail = () => {
   const navigate = useNavigate();
   const [data, setData] = useState<IPaperDetail>();
   const [searchParams] = useSearchParams();
-  const doi = searchParams.get('doi') || '';
+  const [doi, setDoi] = useState<string>(searchParams.get('doi') || '');
   const [hoveredNode, setHoveredNode] = useState('');
   const { data: _data } = useQuery<IPaperDetail>(
     ['paperDetail', doi],
@@ -40,6 +40,7 @@ const PaperDatail = () => {
         const referenceList = data.referenceList.filter((reference) => reference.title);
         return { ...data, referenceList };
       },
+      suspense: false,
     },
   );
 
@@ -56,9 +57,7 @@ const PaperDatail = () => {
   }, []);
 
   const addChildrensNodes = useCallback(async (doi: string) => {
-    const result = (await api.getPaperDetail({ doi }).then((res) => res.data)) as IPaperDetail;
-    const referenceList = result.referenceList.filter((reference) => reference.title);
-    setData({ ...result, referenceList });
+    setDoi(doi);
   }, []);
 
   useEffect(() => {
@@ -73,7 +72,14 @@ const PaperDatail = () => {
         <IconButton icon={<LogoIcon height="30" width="30" />} onClick={handleLogoClick} />
       </Header>
       <Main>
-        {data && <PaperInfo data={data} hoveredNode={hoveredNode} changeHoveredNode={changeHoveredNode} />}
+        {data && (
+          <PaperInfo
+            data={data}
+            hoveredNode={hoveredNode}
+            changeHoveredNode={changeHoveredNode}
+            onClick={addChildrensNodes}
+          />
+        )}
         {data && (
           <ReferenceGraph
             data={data}

--- a/frontend/src/pages/PaperDetail/PaperDetail.tsx
+++ b/frontend/src/pages/PaperDetail/PaperDetail.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Api from '../../api/api';
 import IconButton from '../../components/IconButton';
+import MoonLoader from '../../components/loader/MoonLoader';
 import { PATH_MAIN } from '../../constants/path';
 import LogoIcon from '../../icons/LogoIcon';
 import PreviousButtonIcon from '../../icons/PreviousButtonIcon';
@@ -32,7 +33,7 @@ const PaperDatail = () => {
   const [searchParams] = useSearchParams();
   const [doi, setDoi] = useState<string>(searchParams.get('doi') || '');
   const [hoveredNode, setHoveredNode] = useState('');
-  const { data: _data } = useQuery<IPaperDetail>(
+  const { isLoading, data: _data } = useQuery<IPaperDetail>(
     ['paperDetail', doi],
     () => api.getPaperDetail({ doi }).then((res) => res.data),
     {
@@ -53,7 +54,7 @@ const PaperDatail = () => {
   };
 
   const changeHoveredNode = useCallback((key: string) => {
-    setHoveredNode(key);
+    setHoveredNode(key.toLowerCase());
   }, []);
 
   const addChildrensNodes = useCallback(async (doi: string) => {
@@ -73,23 +74,27 @@ const PaperDatail = () => {
       </Header>
       <Main>
         {data && (
-          <PaperInfo
-            data={data}
-            hoveredNode={hoveredNode}
-            changeHoveredNode={changeHoveredNode}
-            onClick={addChildrensNodes}
-          />
-        )}
-        {data && (
-          <ReferenceGraph
-            data={data}
-            hoveredNode={hoveredNode}
-            changeHoveredNode={changeHoveredNode}
-            addChildrensNodes={addChildrensNodes}
-          />
+          <>
+            <PaperInfo
+              data={data}
+              hoveredNode={hoveredNode}
+              changeHoveredNode={changeHoveredNode}
+              addChildrensNodes={addChildrensNodes}
+            />
+            <ReferenceGraph
+              data={data}
+              hoveredNode={hoveredNode}
+              changeHoveredNode={changeHoveredNode}
+              addChildrensNodes={addChildrensNodes}
+            />
+          </>
         )}
       </Main>
-      )
+      {isLoading && (
+        <LoaderWrapper>
+          <MoonLoader />
+        </LoaderWrapper>
+      )}
     </Container>
   );
 };
@@ -115,6 +120,17 @@ const Main = styled.main`
   display: flex;
   width: 100%;
   height: 100%;
+`;
+
+const LoaderWrapper = styled.div`
+  position: absolute;
+  z-index: 10;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ theme }) => theme.COLOR.primary4}50;
 `;
 
 export default PaperDatail;

--- a/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
+++ b/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
@@ -7,12 +7,12 @@ interface IProps {
   data: IPaperDetail;
   hoveredNode: string;
   changeHoveredNode: (key: string) => void;
-  onClick: (doi: string) => void;
+  addChildrensNodes: (doi: string) => void;
 }
 
 const DOI_BASE_URL = 'https://doi.org/';
 
-const PaperInfo = ({ data, hoveredNode, changeHoveredNode, onClick }: IProps) => {
+const PaperInfo = ({ data, hoveredNode, changeHoveredNode, addChildrensNodes }: IProps) => {
   const handleMouseOver = (key: string) => {
     changeHoveredNode(key);
   };
@@ -51,8 +51,8 @@ const PaperInfo = ({ data, hoveredNode, changeHoveredNode, onClick }: IProps) =>
               key={i}
               onMouseOver={() => handleMouseOver(reference.key)}
               onMouseOut={() => handleMouseOut()}
-              className={`info ${reference.key === hoveredNode ? 'hovered' : ''}`}
-              onClick={() => reference.doi && onClick(reference.doi)}
+              className={`info ${reference.key.toLowerCase() === hoveredNode ? 'hovered' : ''}`}
+              onClick={() => reference.doi && addChildrensNodes(reference.doi)}
             >
               <span>{reference.title}</span>
               <span>{reference.authors?.join(', ') || 'unknown'}</span>

--- a/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
+++ b/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
@@ -53,6 +53,7 @@ const PaperInfo = ({ data, hoveredNode, changeHoveredNode, addChildrensNodes }: 
               onMouseOut={() => handleMouseOut()}
               className={`info ${reference.key.toLowerCase() === hoveredNode ? 'hovered' : ''}`}
               onClick={() => reference.doi && addChildrensNodes(reference.doi)}
+              disabled={!reference.doi}
             >
               <span>{reference.title}</span>
               <span>{reference.authors?.join(', ') || 'unknown'}</span>
@@ -142,11 +143,12 @@ const ReferenceContainer = styled.ul`
   padding: 0 15px;
 `;
 
-const ReferenceItem = styled.li`
+const ReferenceItem = styled.li<{ disabled: boolean }>`
   display: flex;
   flex-direction: column;
   gap: 10px;
-  cursor: pointer;
+  cursor: ${({ disabled }) => (disabled ? 'auto' : 'pointer')};
+  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
 
   span {
     :first-child {
@@ -159,7 +161,7 @@ const ReferenceItem = styled.li`
   }
 
   &.hovered {
-    color: ${({ theme }) => theme.COLOR.secondary2};
+    color: ${({ theme, disabled }) => (!disabled ? theme.COLOR.secondary2 : undefined)};
   }
 `;
 

--- a/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
+++ b/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
@@ -7,11 +7,12 @@ interface IProps {
   data: IPaperDetail;
   hoveredNode: string;
   changeHoveredNode: (key: string) => void;
+  onClick: (doi: string) => void;
 }
 
 const DOI_BASE_URL = 'https://doi.org/';
 
-const PaperInfo = ({ data, hoveredNode, changeHoveredNode }: IProps) => {
+const PaperInfo = ({ data, hoveredNode, changeHoveredNode, onClick }: IProps) => {
   const handleMouseOver = (key: string) => {
     changeHoveredNode(key);
   };
@@ -30,7 +31,7 @@ const PaperInfo = ({ data, hoveredNode, changeHoveredNode }: IProps) => {
         <Title>{sliceTitle(removeTag(data?.title))}</Title>
         <InfoContainer>
           <InfoItem>
-            <h3>{data?.authors.length > 1 ? 'Authors ' : 'Author '}</h3>
+            <h3>{data?.authors?.length > 1 ? 'Authors ' : 'Author '}</h3>
             <span>{data?.authors?.join(', ')}</span>
           </InfoItem>
           <InfoItem>
@@ -51,6 +52,7 @@ const PaperInfo = ({ data, hoveredNode, changeHoveredNode }: IProps) => {
               onMouseOver={() => handleMouseOver(reference.key)}
               onMouseOut={() => handleMouseOut()}
               className={`info ${reference.key === hoveredNode ? 'hovered' : ''}`}
+              onClick={() => reference.doi && onClick(reference.doi)}
             >
               <span>{reference.title}</span>
               <span>{reference.authors?.join(', ') || 'unknown'}</span>

--- a/frontend/src/pages/PaperDetail/components/ReferenceGraph.tsx
+++ b/frontend/src/pages/PaperDetail/components/ReferenceGraph.tsx
@@ -15,7 +15,7 @@ interface ReferenceGraphProps {
   changeHoveredNode: (key: string) => void;
 }
 
-// Todo : any 걷어내기, 구조 리팩터링하기, click 재요청(react-query), 링크 강조, 프론트 테스트
+// Todo : any 걷어내기, 구조 리팩터링하기, 프론트 테스트
 const ReferenceGraph = ({ data, addChildrensNodes, hoveredNode, changeHoveredNode }: ReferenceGraphProps) => {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const linkRef = useRef<SVGGElement | null>(null);
@@ -95,8 +95,7 @@ const Nodes = styled.g`
     fill: ${({ theme }) => theme.COLOR.gray2};
     fill-opacity: 50%;
     font-size: 8px;
-    cursor: pointer;
-
+    cursor: default;
     :hover {
       fill-opacity: 100%;
     }

--- a/frontend/src/pages/PaperDetail/components/ReferenceGraph.tsx
+++ b/frontend/src/pages/PaperDetail/components/ReferenceGraph.tsx
@@ -46,10 +46,7 @@ const ReferenceGraph = ({ data, addChildrensNodes, hoveredNode, changeHoveredNod
         'link',
         d3.forceLink(links).id((d: any) => d.key),
       )
-      .on('tick', () => {
-        if (!linkRef.current || !nodeRef.current) return;
-        ticked(linkRef.current, nodeRef.current);
-      });
+      .on('tick', () => linkRef.current && nodeRef.current && ticked(linkRef.current, nodeRef.current));
 
     return () => {
       simulation.stop();


### PR DESCRIPTION
## 개요
번들 경량화를 위해 라우트별로 코드 스플리팅을 적용했으며 graph 관련 기능 개선 및 citations scale 상수를 변경했습니다.

## 작업사항
- react lazy + suspence로 코드 스플리팅 적용
- paper info에 있는 reference 클릭시에도 노드 추가 이벤트 동일하게 적용
- citations -> color scale 범위 조정
- 자식노드 클릭시 api 호출 로직 react-query로 캐싱되게 수정 + suspence 해제
- doi 없는 논문 disabled 처리
- crossRef로 바로 요청을 보내는 경우, referenceList 내부 값들이 완전하지않은 경우를 고려해 변경된 로직
  1. 논문 key는 항상 소문자로 변환하여 저장합니다.
  2. 정보가 완전하지 않은 자식노드를 클릭했을 때, 해당 노드의 정보 전체가 갈아끼워집니다. 

## 리뷰 요청사항
react-query로 요청을 보낼때마다(해당페이지에서 노드를 추가할 때마다) 깜빡이는 현상이 있어 suspence는 잠시 해제했습니다. 다만 이 경우 페이지 첫 진입시 loader가 돌지 않아 느린 네트워크 환경에서 로더없는 빈 화면이 잠시 노출되는 상황이 생길 수 있습니다. 이 때
1. optimistic update로 Ui만 제공하여 이 현상을 어느정도 절충할지
2. 첫 api 호출만 따로 axois 요청을보내 loader를 노출하는 로직을 작성할지
3. 혹은 새로운 키 하나를 더 만들어 react-query에서 분기처리를 할지
고민이 필요한데, 의견주시면 감사하겠습니다. 그 외 다른 의견도 좋습니다.