### PR TITLE
2-5 [Fix] Frontend Dockerfile 수정

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,13 +3,13 @@ WORKDIR /app
 COPY package*.json .
 RUN npm ci
 COPY . .
+RUN --mount=type=secret,id=REACT_APP_BASE_URL export REACT_APP_BASE_URL=$(cat /run/secrets/REACT_APP_BASE_URL)
 RUN npm run build
 
 FROM nginx:alpine
 WORKDIR /usr/share/nginx/statics
 RUN rm /etc/nginx/conf.d/default.conf
 COPY ./nginx.conf /etc/nginx/conf.d
-RUN --mount=type=secret,id=REACT_APP_BASE_URL export REACT_APP_BASE_URL=$(cat /run/secrets/REACT_APP_BASE_URL) 
 COPY --from=builder /app/build .
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /usr/share/nginx/statics
 RUN rm /etc/nginx/conf.d/default.conf
 COPY ./nginx.conf /etc/nginx/conf.d
 RUN --mount=type=secret,id=REACT_APP_BASE_URL export REACT_APP_BASE_URL=$(cat /run/secrets/REACT_APP_BASE_URL) 
-COPY robots.txt .
 COPY --from=builder /app/build .
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## 개요
* #105 의 frontend Dockerfile을 수정하지 않아 build가 fail 하는 문제를 수정합니다.

## 작업사항
- Dockerfile 내에 robots.txt 삭제

## 리뷰 요청사항
- 빌드가 실패하는 문제가 자주 있지는 않지만, 한번 실패하면 다시 PR을 날려야되는 문제가 있네요.
- 로컬에서 빌드 테스트를 한번 해보고 PR을 올려도 되긴 하지만, 빌드했던 이미지들이 차지하는 용량으로인해 삭제도 해줘야하고 귀찮은 부분이 조금 있습니다.
- PR을 날린 시점에 이미지를 container registry에 push 하고, merge 될 때 배포되는 서버에 접속해서 docker compose pull 하는 방식을 사용할 순 있을 것 같습니다.
  - 이렇게했을 때 장점
    - PR을 머지하는 시점에서 항상 성공한 빌드 이미지만 사용할 수 있어요.
    - PR 올라갈 때 이미지 빌드 CI가 돌아서, merge 하는 시점에는 배포되는 서버가 이미지를 pull만 하면 되므로 배포에 소요되는 시간이 체감상 확 줄어듭니다.
  - 예상되는 문제점
    - Container registry에 이미지가 꽤 많이 쌓일 것 같습니다. (PR 날린 이후의 커밋들에 대해서도 빌드해야하니까)
    - docker compose pull 할 때 어떤 이미지를 가져와야하는지(어떤 tag인지) 알아와야하는 로직이 필요한데 바로 떠오르진 않네요.
- 다른 팀들은 어떻게 하고 있나 조사를 한번 해보겠습니다~
