### PR TITLE
[Fix] referenceLink 없을 때 노드 업데이트 되지않는 오류 해결

### DIFF
--- a/frontend/src/hooks/graph/useGraphData.ts
+++ b/frontend/src/hooks/graph/useGraphData.ts
@@ -48,7 +48,7 @@ export default function useGraphData<T>(data: IPaperDetail) {
       source: data.key.toLowerCase(),
       target: reference.key.toLowerCase(),
     }));
-    if (newLinks.length > 0) setLinks((prev) => [...prev, ...newLinks]);
+    setLinks((prev) => [...prev, ...newLinks]);
   }, [data]);
 
   return { nodes: nodes.current, links } as T;


### PR DESCRIPTION
## 개요
referenceLink 없을 때 자식노드가 업데이트 되지않는 오류를 해결했습니다.

## 작업사항
- referenceLink 없을 때 자식노드가 업데이트 되지않는 오류를 해결했습니다. link의 변경사항이 없어도 state를 갈아끼워줘야 simulation이 다시 돌면서 노드에 반영되므로 항상 link가 업데이트되게 로직을 수정했습니다.
- #111 fix

## 리뷰 요청사항
- N/A
