### PR TITLE
[Feature] doi로 검색시 바로 상세페이지 접근하는 기능 추가

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,16 +5,20 @@
   <meta charset="utf-8" />
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="Web site created using create-react-app" />
+  <meta name="description" content="논문 간 인용관계 시각화" />
   <meta property="og:type" content="website">
   <meta property="og:url" content="%PUBLIC_URL%/">
   <meta property="og:title" content="PRV - Paper Reference Visualization">
   <meta property="og:image" content="%PUBLIC_URL%/assets/prv-image.png">
   <meta property="og:image:width" content="2084">
   <meta property="og:image:height" content="1244">
-  <meta property="og:description" content="논문간 인용관계 시각화">
+  <meta property="og:description" content="논문 간 인용관계 시각화">
   <meta property="og:site_name" content="PRV - Paper Reference Visualization">
   <meta property="og:locale" content="ko_KR">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="PRV - Paper Reference Visualization">
+  <meta name="twitter:image" content="%PUBLIC_URL%/assets/prv-image.png">
+  <meta name="twitter:url" content="%PUBLIC_URL%/">
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&display=swap" rel="stylesheet">
   <link rel="preload" href="assets/moon.png" as="image" type="image/png" />
   <title>PRV</title>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,8 +47,8 @@ function App() {
             <Routes>
               <Route path={PATH_MAIN} element={<Main />} />
               <Route path={PATH_SEARCH_LIST} element={<SearchList />} />
-              <Route path={'*'} element={<GlobalErrorFallback />} />
               <Route path={PATH_DETAIL} element={<PaperDatail />} />
+              <Route path={'*'} element={<GlobalErrorFallback />} />
             </Routes>
           </Suspense>
         </ErrorBoundary>

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1,16 +1,57 @@
 import axios, { AxiosInstance } from 'axios';
+
+export interface IRankingData {
+  keyword: string;
+  count: number;
+}
+
+export interface IPapersData {
+  papers: IPaper[];
+  pageInfo: IPageInfo;
+}
+
 export interface IGetSearch {
   keyword: string;
   page: string;
   rows?: string;
 }
-
 export interface IGetAutoComplete {
   keyword: string;
 }
-
+export interface IAutoCompletedItem {
+  authors?: string[];
+  doi: string;
+  title: string;
+}
 export interface IGetPaperDetail {
   doi: string;
+}
+export interface IPaperDetail extends IPaper {
+  referenceList: IReference[];
+}
+
+export interface IReference {
+  key: string;
+  title?: string;
+  authors?: string[];
+  doi?: string;
+  publishedAt?: string;
+  citations?: number;
+  references?: number;
+}
+export interface IPaper {
+  title: string;
+  authors: string[];
+  doi: string;
+  key: string;
+  publishedAt: string;
+  citations: number;
+  references: number;
+}
+
+export interface IPageInfo {
+  totalItems: number;
+  totalPages: number;
 }
 
 export default class Api {
@@ -21,22 +62,26 @@ export default class Api {
     this.instance = axios.create({ baseURL: this.baseURL });
   }
 
-  getKeywordRanking() {
-    return this.instance.get('/keyword-ranking');
+  async getKeywordRanking(): Promise<IRankingData[]> {
+    const res = await this.instance.get('/keyword-ranking');
+    return res.data;
   }
 
-  getSearch(params: IGetSearch) {
+  async getSearch(params: IGetSearch): Promise<IPapersData> {
     params.keyword = decodeURI(params.keyword);
-    return this.instance.get('/search', {
+    const res = await this.instance.get('/search', {
       params,
     });
+    return res.data;
   }
 
-  getAutoComplete(params: IGetAutoComplete) {
-    return this.instance.get('/search/auto-complete', { params });
+  async getAutoComplete(params: IGetAutoComplete): Promise<IAutoCompletedItem[]> {
+    const res = await this.instance.get('/search/auto-complete', { params });
+    return res.data;
   }
 
-  getPaperDetail(params: IGetPaperDetail) {
-    return this.instance.get(`/search/paper`, { params });
+  async getPaperDetail(params: IGetPaperDetail): Promise<IPaperDetail> {
+    const res = await this.instance.get(`/search/paper`, { params });
+    return res.data;
   }
 }

--- a/frontend/src/components/search/AutoCompletedList.tsx
+++ b/frontend/src/components/search/AutoCompletedList.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction, useEffect } from 'react';
 import styled from 'styled-components';
-import { MAX_TITLE_LENGTH } from '../../constants/main';
-import { IAutoCompletedItem } from './Search';
+import { IAutoCompletedItem } from '../../api/api';
+import { removeTag, sliceTitle } from '../../utils/format';
 
 interface AutoCompletedListProps {
   autoCompletedItems?: IAutoCompletedItem[];
@@ -64,11 +64,7 @@ const AutoCompletedList = ({
             onMouseOver={() => setHoveredIndex(i)}
             onMouseDown={() => handleAutoCompletedDown(i)}
           >
-            <Title>
-              {highlightKeyword(
-                item.title.length > MAX_TITLE_LENGTH ? `${item.title.slice(0, MAX_TITLE_LENGTH)}...` : item.title,
-              )}
-            </Title>
+            <Title>{highlightKeyword(sliceTitle(removeTag(item.title)))}</Title>
             {item.authors && (
               <Author>
                 authors : {highlightKeyword(getRepresentativeAuthor(item.authors))}

--- a/frontend/src/components/search/Search.tsx
+++ b/frontend/src/components/search/Search.tsx
@@ -7,7 +7,7 @@ import { PATH_SEARCH_LIST } from '../../constants/path';
 import useDebounceValue from '../../hooks/useDebouncedValue';
 import MaginifyingGlassIcon from '../../icons/MagnifyingGlassIcon';
 import { createDetailQuery } from '../../utils/createQuery';
-import { isDoiFormat } from '../../utils/format';
+import { getDoiKey, isDoiFormat } from '../../utils/format';
 import { getLocalStorage, setLocalStorage } from '../../utils/localStorage';
 import IconButton from '../IconButton';
 import MoonLoader from '../loader/MoonLoader';
@@ -32,7 +32,6 @@ const Search = ({ initialKeyword = '' }: SearchProps) => {
   const [recentKeywords, setRecentKeywords] = useState<string[]>([]);
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [hoverdIndex, setHoveredIndex] = useState<number>(-1);
-  const [doi, setDoi] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
   const debouncedValue = useDebounceValue(keyword, 150);
@@ -45,23 +44,6 @@ const Search = ({ initialKeyword = '' }: SearchProps) => {
       suspense: false,
     },
   );
-
-  useQuery<IPaperDetail>(['paperDetail', doi?.toLowerCase()], () => api.getPaperDetail({ doi }), {
-    select: (data) => {
-      const referenceList = data.referenceList.filter((reference) => reference.title);
-      return { ...data, referenceList };
-    },
-    enabled: !!doi,
-    suspense: false,
-    useErrorBoundary: true,
-    onSuccess: () => {
-      // 유효 DOI라면 상세페이지로 이동
-      goToDetailPage(keyword);
-    },
-    onError: () => {
-      goToSearchList(keyword);
-    },
-  });
 
   const navigate = useNavigate();
 
@@ -132,7 +114,7 @@ const Search = ({ initialKeyword = '' }: SearchProps) => {
 
     // DOI 형식의 input이 들어온 경우
     if (isDoiFormat(newKeyword)) {
-      setDoi(newKeyword);
+      goToDetailPage(getDoiKey(newKeyword));
       return;
     }
     goToSearchList(newKeyword);

--- a/frontend/src/hooks/graph/useGraphData.ts
+++ b/frontend/src/hooks/graph/useGraphData.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { IPaperDetail } from './../../pages/PaperDetail/PaperDetail';
+import { IPaperDetail } from './../../api/api';
 
 export default function useGraphData<T>(data: IPaperDetail) {
   const [links, setLinks] = useState<any[]>([]);

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -18,7 +18,7 @@ const Main = () => {
         </TitleContainer>
         <ContentContainer>
           <div>Paper Reference Visualization</div>
-          <div>논문간 인용관계 시각화 솔루션</div>
+          <div>논문 간 인용관계 시각화 솔루션</div>
           <div>This website renders reference relation of paper</div>
         </ContentContainer>
         <ErrorBoundary fallback={RankingErrorFallback}>

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -24,6 +24,9 @@ const Main = () => {
         <ErrorBoundary fallback={RankingErrorFallback}>
           <KeywordRanking />
         </ErrorBoundary>
+        <Text>
+          * DOI로 직접 검색하시면 원하는 논문을 바로 찾을 수 있습니다.{'\n'}(DOI 형식 : https://doi.org/xxxxx)
+        </Text>
         <Search />
       </MainContainer>
       <Positioner>
@@ -71,6 +74,13 @@ const Positioner = styled.div`
   position: absolute;
   bottom: 0;
   width: 100%;
+`;
+
+const Text = styled.div`
+  white-space: pre-line;
+  text-align: center;
+  ${({ theme }) => theme.TYPO.body2}
+  line-height : 1.5
 `;
 
 export default Main;

--- a/frontend/src/pages/Main/components/KeywordRanking.tsx
+++ b/frontend/src/pages/Main/components/KeywordRanking.tsx
@@ -2,17 +2,12 @@ import { useState } from 'react';
 import { useQuery } from 'react-query';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import Api from '../../../api/api';
+import Api, { IRankingData } from '../../../api/api';
 import IconButton from '../../../components/IconButton';
 import DropdownIcon from '../../../icons/DropdownIcon';
 import DropDownReverseIcon from '../../../icons/DropdownReverseIcon';
 import { createSearchQuery } from '../../../utils/createQuery';
 import RankingSlide from './RankingSlide';
-
-interface IRankingData {
-  keyword: string;
-  count: number;
-}
 
 const api = new Api();
 
@@ -20,7 +15,7 @@ const KeywordRanking = () => {
   const [isRankingListOpen, setIsRankingListOpen] = useState(false);
   const { isLoading, data: rankingData } = useQuery<IRankingData[]>(
     'getKeywordRanking',
-    () => api.getKeywordRanking().then((res) => res.data),
+    () => api.getKeywordRanking(),
     {
       suspense: false,
     },

--- a/frontend/src/pages/PaperDetail/PaperDetail.tsx
+++ b/frontend/src/pages/PaperDetail/PaperDetail.tsx
@@ -2,47 +2,35 @@ import { useCallback, useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
-import Api from '../../api/api';
+import Api, { IPaperDetail } from '../../api/api';
 import IconButton from '../../components/IconButton';
 import MoonLoader from '../../components/loader/MoonLoader';
 import { PATH_MAIN } from '../../constants/path';
 import LogoIcon from '../../icons/LogoIcon';
 import PreviousButtonIcon from '../../icons/PreviousButtonIcon';
-import { IPaper } from '../SearchList/SearchList';
 import PaperInfo from './components/PaperInfo';
 import ReferenceGraph from './components/ReferenceGraph';
-
-export interface IReference {
-  key: string;
-  title?: string;
-  authors?: string[];
-  doi?: string;
-  publishedAt?: string;
-  citations?: number;
-  references?: number;
-}
-export interface IPaperDetail extends IPaper {
-  referenceList: IReference[];
-}
 
 const api = new Api();
 
 const PaperDatail = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const [data, setData] = useState<IPaperDetail>();
+  const [data, setData] = useState<IPaperDetail>(location.state?.initialData);
   const [searchParams] = useSearchParams();
-  const [doi, setDoi] = useState<string>(searchParams.get('doi') || '');
+  // 넘겨받은 데이터가 없는경우만 query에서 doi 정보를 가져온다
+  const [doi, setDoi] = useState<string>(location.state?.initialData ? '' : searchParams.get('doi') || '');
   const [hoveredNode, setHoveredNode] = useState('');
 
   const { isLoading, data: _data } = useQuery<IPaperDetail>(
     ['paperDetail', doi.toLowerCase()],
-    () => api.getPaperDetail({ doi }).then((res) => res.data),
+    () => api.getPaperDetail({ doi }),
     {
       select: (data) => {
         const referenceList = data.referenceList.filter((reference) => reference.title);
         return { ...data, referenceList };
       },
+      enabled: !!doi,
       suspense: false,
     },
   );

--- a/frontend/src/pages/PaperDetail/PaperDetail.tsx
+++ b/frontend/src/pages/PaperDetail/PaperDetail.tsx
@@ -18,8 +18,7 @@ const PaperDatail = () => {
   const location = useLocation();
   const [data, setData] = useState<IPaperDetail>(location.state?.initialData);
   const [searchParams] = useSearchParams();
-  // 넘겨받은 데이터가 없는경우만 query에서 doi 정보를 가져온다
-  const [doi, setDoi] = useState<string>(location.state?.initialData ? '' : searchParams.get('doi') || '');
+  const [doi, setDoi] = useState<string>(searchParams.get('doi') || '');
   const [hoveredNode, setHoveredNode] = useState('');
 
   const { isLoading, data: _data } = useQuery<IPaperDetail>(
@@ -30,8 +29,8 @@ const PaperDatail = () => {
         const referenceList = data.referenceList.filter((reference) => reference.title);
         return { ...data, referenceList };
       },
-      enabled: !!doi,
       suspense: false,
+      useErrorBoundary: true,
     },
   );
 

--- a/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
+++ b/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
+import { IPaperDetail } from '../../../api/api';
 import { Ellipsis } from '../../../style/styleUtils';
 import { removeTag, sliceTitle } from '../../../utils/format';
-import { IPaperDetail } from '../PaperDetail';
 
 interface IProps {
   data: IPaperDetail;
@@ -119,7 +119,8 @@ const References = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
-  overflow: scroll;
+  overflow-y: scroll;
+  overflow-x: hidden;
   h3 {
     ${({ theme }) => theme.TYPO.body_h};
     padding: 0 15px;
@@ -141,6 +142,7 @@ const ReferenceItem = styled.li<{ disabled: boolean }>`
   opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
 
   span {
+    word-break: break-all;
     :first-child {
       ${({ theme }) => theme.TYPO.body2_h};
       line-height: 1.1rem;

--- a/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
+++ b/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
@@ -33,6 +33,7 @@ const PaperInfo = ({ data, hoveredNode, changeHoveredNode, addChildrensNodes }: 
           <InfoItem>
             <h3>DOI</h3>
             <a href={DOI_BASE_URL + data?.doi} target="_blank" rel="noopener noreferrer">
+              {DOI_BASE_URL}
               {data?.doi}
             </a>
           </InfoItem>

--- a/frontend/src/pages/PaperDetail/components/ReferenceGraph.tsx
+++ b/frontend/src/pages/PaperDetail/components/ReferenceGraph.tsx
@@ -1,12 +1,12 @@
 import * as d3 from 'd3';
 import { useEffect, useRef } from 'react';
 import styled from 'styled-components';
+import { IPaperDetail } from '../../../api/api';
 import useGraphData from '../../../hooks/graph/useGraphData';
 import useGraphEmphasize from '../../../hooks/graph/useGraphEmphasize';
 import useGraphZoom from '../../../hooks/graph/useGraphZoom';
 import useLinkUpdate from '../../../hooks/graph/useLinkUpdate';
 import useNodeUpdate from '../../../hooks/graph/useNodeUpdate';
-import { IPaperDetail } from '../PaperDetail';
 
 interface ReferenceGraphProps {
   data: IPaperDetail;

--- a/frontend/src/pages/SearchList/SearchList.tsx
+++ b/frontend/src/pages/SearchList/SearchList.tsx
@@ -8,21 +8,6 @@ import theme from '../../style/theme';
 import SearchBarHeader from './components/SearchBarHeader';
 import SearchResults from './components/SearchResults';
 
-export interface IPaper {
-  title: string;
-  authors: string[];
-  doi: string;
-  key: string;
-  publishedAt: string;
-  citations: number;
-  references: number;
-}
-
-export interface IPageInfo {
-  totalItems: number;
-  totalPages: number;
-}
-
 const SearchList = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const params = useMemo<IGetSearch>(() => {

--- a/frontend/src/pages/SearchList/components/Paper.tsx
+++ b/frontend/src/pages/SearchList/components/Paper.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
+import { IPaper } from '../../../api/api';
 import { Ellipsis } from '../../../style/styleUtils';
 import { highlightKeyword, removeTag, sliceTitle } from '../../../utils/format';
-import { IPaper } from '../SearchList';
 
 interface PaperProps {
   data: IPaper;

--- a/frontend/src/pages/SearchList/components/SearchResults.tsx
+++ b/frontend/src/pages/SearchList/components/SearchResults.tsx
@@ -2,10 +2,9 @@ import { isEmpty } from 'lodash-es';
 import { useQuery } from 'react-query';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import Api, { IGetSearch } from '../../../api/api';
+import Api, { IGetSearch, IPapersData } from '../../../api/api';
 import Pagination from '../../../components/Pagination';
 import { createDetailQuery } from '../../../utils/createQuery';
-import { IPageInfo, IPaper } from '../SearchList';
 import Paper from './Paper';
 
 interface SearchResultsProps {
@@ -13,17 +12,12 @@ interface SearchResultsProps {
   changePage: (page: number) => void;
 }
 
-interface IPapersData {
-  papers: IPaper[];
-  pageInfo: IPageInfo;
-}
-
 const api = new Api();
 
 const SearchResults = ({ params, changePage }: SearchResultsProps) => {
   const keyword = params.keyword || '';
   const page = Number(params.page);
-  const { data } = useQuery<IPapersData>(['papers', params], () => api.getSearch(params).then((res) => res.data), {
+  const { data } = useQuery<IPapersData>(['papers', params], () => api.getSearch(params), {
     enabled: !isEmpty(params),
   });
 

--- a/frontend/src/utils/format.tsx
+++ b/frontend/src/utils/format.tsx
@@ -26,5 +26,9 @@ export const sliceTitle = (title: string) => {
 };
 
 export const isDoiFormat = (doi: string) => {
-  return RegExp(/^[\d]{2}\.[\d]{1,}\/.*/).test(doi);
+  return RegExp(/^https:\/\/doi.org\/([\d]{2}\.[\d]{1,}\/.*)/i).test(doi);
+};
+
+export const getDoiKey = (doi: string) => {
+  return doi.match(RegExp(/^https:\/\/doi.org\/([\d]{2}\.[\d]{1,}\/.*)/i))?.[1] || '';
 };

--- a/frontend/src/utils/format.tsx
+++ b/frontend/src/utils/format.tsx
@@ -24,3 +24,7 @@ export const highlightKeyword = (text: string, keyword: string) => {
 export const sliceTitle = (title: string) => {
   return title.length > MAX_TITLE_LENGTH ? `${title.slice(0, MAX_TITLE_LENGTH)}...` : title;
 };
+
+export const isDoiFormat = (doi: string) => {
+  return RegExp(/^[\d]{2}\.[\d]{1,}\/.*/).test(doi);
+};


### PR DESCRIPTION
## 개요
doi로 검색시 바로 상세페이지로 이동하는 기능을 추가했습니다.

## 작업사항
- doi로 검색시 바로 상세페이지로 이동하는 기능을 추가했습니다. 검색하려는 키워드가 doi 포맷이면 `GET /search/paper` 요청을 보내고, 에러 반환시 search-list 페이지로, 성공시 detail 페이지로 이동합니다.
- doi 검색시 `GET /search/paper` call을 한번만 하기위해 detail 페이지로 라우트 이동시 이전에 받은 doi 요청결과를 state로 가져갑니다.
- og tag를 업데이트 했습니다.
- 자동완성 목록에 tag 제거로직 누락되어있던부분 수정했습니다.

## 리뷰 요청사항
- doi가 유효한지 확인하는동안 로딩을 어떻게 보여줄지에 대한 논의가 필요합니다.

## 실행화면
![Dec-09-2022 21-52-27](https://user-images.githubusercontent.com/30085476/206706833-3eed2146-5f03-40d4-a906-87d8964a5f9a.gif)
