### PR TITLE
[Fix/redis-insert]- 2글자 이하 입력 시 redis에서 error를 throw하는 에러 수정

### DIFF
--- a/backend/src/batch/tests/batch.service.spec.ts
+++ b/backend/src/batch/tests/batch.service.spec.ts
@@ -9,7 +9,7 @@ describe('doiBatcher', () => {
   beforeEach(() => {
     const httpService = mockHttpService();
     const elasticService = mockElasticService();
-    service = new BatchService(mockRedisQueue(popDoiItem), httpService, new SearchService(elasticService));
+    service = new BatchService(mockRedisQueue(popDoiItem), httpService, new SearchService(elasticService, httpService));
   });
   it('run doi batch', async () => {
     const doiBatcher__runBatch = jest.spyOn(service.doiBatcher, 'runBatch');

--- a/backend/src/batch/tests/batcher.spec.ts
+++ b/backend/src/batch/tests/batcher.spec.ts
@@ -12,7 +12,12 @@ describe('doiBatcher', () => {
     const redisService = mockRedisQueue(popDoiItem);
     const httpService = mockHttpService();
     const elasticService = mockElasticService();
-    batcher = new DoiBatcher(redisService, httpService.axiosRef, new SearchService(elasticService), 'doi batcher');
+    batcher = new DoiBatcher(
+      redisService,
+      httpService.axiosRef,
+      new SearchService(elasticService, httpService),
+      'doi batcher',
+    );
   });
   it('getParamsFromUrl', async () => {
     const items = await batcher.queue.pop(1);
@@ -29,7 +34,12 @@ describe('searchBatcher', () => {
     const redisService = mockRedisQueue(popSearchItem);
     const httpService = mockHttpService();
     const elasticService = mockElasticService();
-    batcher = new SearchBatcher(redisService, httpService.axiosRef, new SearchService(elasticService), 'doi batcher');
+    batcher = new SearchBatcher(
+      redisService,
+      httpService.axiosRef,
+      new SearchService(elasticService, httpService),
+      'doi batcher',
+    );
   });
   it('getParamsFromUrl', async () => {
     const items = await batcher.queue.pop(1);

--- a/backend/src/ranking/ranking.service.ts
+++ b/backend/src/ranking/ranking.service.ts
@@ -23,7 +23,7 @@ export class RankingService {
     return result;
   }
   async insertRedis(data: string) {
-    if (data === '' || data.length <= 2) throw new BadRequestException();
+    if (data === '' || data.length < 2) return;
     const encodeData = decodeURI(data);
     try {
       const isRanking: string = await this.redis.zscore(process.env.REDIS_POPULAR_KEY, encodeData);

--- a/backend/src/search/tests/search.controller.spec.ts
+++ b/backend/src/search/tests/search.controller.spec.ts
@@ -124,8 +124,8 @@ describe('SearchController', () => {
     it(`getPaper - doi=10.1234/some_doi 일 때 PaperInfoDetail을 return`, async () => {
       const doi = '10.1234/some_doi';
       const paper = await controller.getPaper({ doi });
-      expect(paper.references).toBe(10);
-      expect(paper.referenceList.length).toBe(10);
+      expect(paper.references).toBe(5);
+      expect(paper.referenceList.length).toBe(5);
       expect(() => new PaperInfoDetail(paper)).not.toThrow();
     });
     it('doi가 입력되지 않을 경우 error - GET /search/paper?doi=', () => {


### PR DESCRIPTION
## 개요
입력값을 2글자 미만인 경우를 validation pipe에서 막고 있었으나, redis검증 로직에서 2글자 이하인 경우를 에러를 내는 설계 오류가 있었습니다.
## 작업사항
- 2글자 미만일시 return으로 변경하였습니다.