### PR TITLE
14-11 [BE] [논문 상세 - 네트워크 차트] 논문 reference의 중복 키 제거

### DIFF
--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import {
   CrossRefItem,
   PaperInfoExtended,
@@ -40,20 +40,33 @@ export class SearchService {
     return new PaperInfoExtended(data);
   };
   parsePaperInfoDetail = (item: CrossRefItem) => {
+    const keysTable: { [key: string]: boolean } = {};
     const referenceList =
-      item['reference']?.map((reference) => {
-        return {
-          key: reference['DOI'] || reference.key || reference.unstructured,
-          title:
+      item['reference']
+        ?.map((reference) => {
+          const key = reference['DOI'] || reference.key || reference.unstructured;
+          const title =
             reference['article-title'] ||
             reference['journal-title'] ||
             reference['series-title'] ||
             reference['volume-title'] ||
-            reference.unstructured,
-          doi: reference['DOI'],
-          authors: reference['author'] ? [reference['author']] : undefined,
-        };
-      }) || [];
+            reference.unstructured;
+          const doi = reference['DOI'];
+          const authors = reference['author'] ? [reference['author']] : undefined;
+          return {
+            key,
+            title,
+            doi,
+            authors,
+          };
+        })
+        .filter((reference) => {
+          if (!keysTable[reference.key]) {
+            keysTable[reference.key] = true;
+            return true;
+          }
+          return false;
+        }) || [];
     const data = {
       ...this.parsePaperInfoExtended(item),
       referenceList,


### PR DESCRIPTION
## 개요
- referenceList의 key는 DOI일 수도, DOI가 아닐 수도 있습니다.
- crossref에서는 key에 중복된 값을 전달해주기도 합니다.
- 우리 db에도 references에 중복된 item이 배열로 들어있을 수 있습니다.

## 작업사항
- `keysTable: {[key: string]: boolean}` 을 만들어서 중복되는 key이면 전달하지 않음.

## 리뷰 요청사항
- N/A
