### PR TITLE
[hotfix][FE] XIcon export 오류 수정

### DIFF
--- a/frontend/src/icons/XIcon.tsx
+++ b/frontend/src/icons/XIcon.tsx
@@ -6,4 +6,4 @@ const XIcon = () => {
   );
 };
 
-export default XMark;
+export default XIcon;


### PR DESCRIPTION
## 개요
XMark 아이콘 이름을 XIcon으로 수정하면서 수정이 완벽하지 않아 FE 빌드가 Fail하는 사항 수정

## 작업사항
- XIcon 컴포넌트 export 오류 수정
- XMark -> XIcon 파일 이름 수정

* 다른 FE PR 머지 이전에 머지되어야 하는 PR입니다.
