### PR TITLE
[hotfix]: removeTag 예외처리

### DIFF
--- a/frontend/src/utils/format.tsx
+++ b/frontend/src/utils/format.tsx
@@ -3,7 +3,7 @@ import { Emphasize } from '@/style/styleUtils';
 const MAX_TITLE_LENGTH = 150;
 
 export const removeTag = (text: string) => {
-  return text.replace(/<[^>]*>?/g, ' ');
+  return text?.replace(/<[^>]*>?/g, ' ') || '';
 };
 
 export const highlightKeyword = (text: string, keyword: string) => {


### PR DESCRIPTION
## 개요
removeTag parameter가 string 이 아닌 경우 예외처리

## 작업사항
- removeTag parameter가 string 이 아닌 경우 예외처리

## 리뷰 요청사항
text.replace에서 undefined 오류가 발생하면서 404페이지로 대체되는 케이스를 발견했습니다.
text가 title이 string으로 들어오지 않는 일부 사례가 있는 듯 보입니다만 해당 사례가 재현이 되지않아 어떤 케이스인지 정확히 파악이 안되네요. 발견하신다면 제보바랍니다.