### PR TITLE
[BE] elasticsearch 검색 로직 수정

### DIFF
--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -101,21 +101,18 @@ export class SearchService {
     });
   }
   async getElasticSearch(keyword: string, size = 5, from = 0) {
+    const key = decodeURIComponent(keyword);
     const query = {
       bool: {
         should: [
           {
-            match_bool_prefix: {
-              title: {
-                query: keyword,
-              },
+            match_phrase_prefix: {
+              title: key,
             },
           },
           {
-            match_bool_prefix: {
-              author: {
-                query: keyword,
-              },
+            match_phrase_prefix: {
+              authors: key,
             },
           },
         ],


### PR DESCRIPTION
## 개요
띄어쓰기 포함해도 검색 됩니다.

## 작업사항
- keyword가 encode되어 들어오고 있어서 띄어쓰기가 '%20' 으로 검색되고 있었습니다. -> decode
- query 내부에 match_bool_prefix를  match_phrase_prefix로 수정했습니다.
  - [match_phrase_prefix](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase-prefix.html)
- author -> authors로 수정했습니다.

## 리뷰 요청사항
- N/A
