### PR TITLE
[BE] keyword 검색시 crossref로 검색하는 로직 추가

### DIFF
--- a/backend/src/ranking/ranking.controller.ts
+++ b/backend/src/ranking/ranking.controller.ts
@@ -12,8 +12,4 @@ export class RankingController {
   async getTen() {
     return await this.rankingService.getTen();
   }
-  @Get('/insert')
-  async insertCache(@Query('keyword') searchStr: string) {
-    return this.rankingService.insertRedis(searchStr);
-  }
 }

--- a/backend/src/ranking/tests/ranking.controller.spec.ts
+++ b/backend/src/ranking/tests/ranking.controller.spec.ts
@@ -21,23 +21,23 @@ describe('RankingServiceTest', () => {
   describe('/keyword-ranking', () => {
     it('redis date가 10개 이하인 경우', async () => {
       //Case 1. redis date가 10개 이하인 경우
-      const topTen = await controller.getTen();
+      const topTen = await service.getTen();
       expect(topTen.length).toBeLessThanOrEqual(10);
     });
     it('데이터 삽입 후 topTen 체크', async () => {
       //Case 2. 데이터 삽입 후 topTen 체크
-      const flag = await controller.insertCache('9번째 데이터');
+      const flag = await service.insertRedis('9번째 데이터');
       expect(flag).toBe('new');
       const topTen = await controller.getTen();
       expect(topTen.length).toBe(9);
-      const flag2 = await controller.insertCache('10번째 데이터');
+      const flag2 = await service.insertRedis('10번째 데이터');
       expect(flag2).toBe('new');
       const topTen2 = await controller.getTen();
       expect(topTen2.length).toBe(10);
     });
     it('2위인 "사랑해요" 데이터가 한번 더 검색시 1위로 업데이트', async () => {
       //Case 3. 2위인 "사랑해요" 데이터가 한번 더 검색시 1위로 업데이트
-      const flag = await controller.insertCache('사랑해요');
+      const flag = await service.insertRedis('사랑해요');
       expect(flag).toBe('update');
       const topTen = await controller.getTen();
       expect(topTen[0].keyword).toBe('부스트캠프');
@@ -46,23 +46,23 @@ describe('RankingServiceTest', () => {
   describe('/keyword-ranking/insert', () => {
     // Case1. 기존 redis에 없던 데이터 삽입
     it('기존 redis에 없던 데이터 삽입', async () => {
-      const result = await controller.insertCache('newData');
+      const result = await service.insertRedis('newData');
       expect(result).toBe('new');
     });
     // Case2. 기존 redis에 있던 데이터 삽입
     it('기존 redis에 있던 데이터 삽입', async () => {
-      const result = await controller.insertCache('부스트캠프');
+      const result = await service.insertRedis('부스트캠프');
       expect(result).toBe('update');
     });
     //Case3. redis에 빈 검색어 입력
     it('빈 검색어 redis에 삽입', async () => {
-      await expect(controller.insertCache('')).rejects.toEqual(
+      await expect(service.insertRedis('')).rejects.toEqual(
         new BadRequestException({ status: 400, error: 'bad request' }),
       );
     });
     //Case4. insert 실패시 타임 아웃 TimeOut
     it('insert 실패시 타임 아웃 TimeOut', async () => {
-      await expect(controller.insertCache('')).rejects.toEqual(
+      await expect(service.insertRedis('')).rejects.toEqual(
         new BadRequestException({ status: 400, error: 'bad request' }),
       );
     });

--- a/backend/src/search/search.controller.ts
+++ b/backend/src/search/search.controller.ts
@@ -46,6 +46,18 @@ export class SearchController {
     const keywordHasSet = await this.batchService.setKeyword(keyword);
     if (keywordHasSet) this.batchService.searchBatcher.pushToQueue(0, 0, -1, true, keyword);
 
+    // Elasticsearch 검색 결과가 없을 경우, Crossref 검색
+    if (totalItems === 0) {
+      const { items: papers, totalItems } = await this.searchService.getPapersFromCrossref(keyword, rows, page);
+      return {
+        papers,
+        pageInfo: {
+          totalItems,
+          totalPages: Math.ceil(totalItems / rows),
+        },
+      };
+    }
+
     const papers = data.hits.hits.map((paper) => new PaperInfoExtended(paper._source));
     return {
       papers,

--- a/backend/src/util.ts
+++ b/backend/src/util.ts
@@ -1,7 +1,12 @@
 import { MAIL_TO } from './envLayer';
 
 const BASE_URL = 'https://api.crossref.org/works';
-export const CROSSREF_API_URL = (keyword: string, rows = 5, page = 1, selects: string[] = ['author', 'title', 'DOI']) =>
+export const CROSSREF_API_URL = (
+  keyword: string,
+  rows = 5,
+  page = 1,
+  selects: string[] = ['title', 'author', 'created', 'is-referenced-by-count', 'references-count', 'DOI'],
+) =>
   `${BASE_URL}?query=${keyword}&rows=${rows}&select=${selects.join(',')}&offset=${rows * (page - 1)}&mailto=${MAIL_TO}`;
 
 export const MAX_ROWS = 1000;


### PR DESCRIPTION
## 개요
정확한 키워드로 논문을 검색할 경우, 검색결과가 없으면 우리 서비스에 대한 신뢰도가 떨어질 수 있습니다.
이 때 crossref 검색 로직을 사용합니다.

## 작업사항
- elasticsearch로 검색했을 때, 아무런 결과가 없을 경우(우리 db에 해당 논문이 없을 경우) crossref API를 사용하여 검색합니다. (이전 로직 사용)
- 이 PR로 인해 too many request가 뜰 수도 있지만, 꽤 많은 사용자가 몰려야 하겠습니다. (1초에 요청 50회 이상)
- `keyword-ranking/insert` 를 삭제했습니다.

## 리뷰 요청사항
- N/A
