### PR TITLE
[FE] doi key로도 검색할 수 있게 정규식 수정

### DIFF
--- a/frontend/src/utils/format.tsx
+++ b/frontend/src/utils/format.tsx
@@ -27,9 +27,9 @@ export const sliceTitle = (title: string) => {
 };
 
 export const isDoiFormat = (doi: string) => {
-  return RegExp(/^https:\/\/doi.org\/([\d]{2}\.[\d]{1,}\/.*)/i).test(doi);
+  return RegExp(/^(https:\/\/doi.org\/)*([\d]{2}\.[\d]{1,}\/.*)$/i).test(doi);
 };
 
 export const getDoiKey = (doi: string) => {
-  return doi.match(RegExp(/^https:\/\/doi.org\/([\d]{2}\.[\d]{1,}\/.*)/i))?.[1] || '';
+  return doi.match(RegExp(/^(https:\/\/doi.org\/)*([\d]{2}\.[\d]{1,}\/.*)$/i))?.[2] || '';
 };


### PR DESCRIPTION
## 개요
https://doi.org/~, doi key 두가지 형식 모두 검색할 수 있게 정규식을 수정했습니다.

## 작업사항
- https://doi.org/~, doi key 두가지 형식 모두 검색할 수 있게 정규식을 수정했습니다. api 쿼리에는 doi key만 전달됩니다.

## 리뷰 요청사항
- N/A
