### PR TITLE
[FE] 그래프 가시성 개선

### DIFF
--- a/frontend/src/hooks/graph/useGraph.ts
+++ b/frontend/src/hooks/graph/useGraph.ts
@@ -56,6 +56,7 @@ const useGraph = (
         .attr('x', (d) => d.x || null)
         .attr('y', (d) => (d.y ? d.y + 10 : null))
         .attr('dy', 5)
+        .style('font-weight', 700)
         .on('mouseover', (_, d) => d.doi && changeHoveredNode(d.key))
         .on('mouseout', () => changeHoveredNode(''))
         .on('click', (_, d) => d.doi && addChildrensNodes(d.doi));

--- a/frontend/src/hooks/graph/useGraphEmphasize.ts
+++ b/frontend/src/hooks/graph/useGraphEmphasize.ts
@@ -6,7 +6,7 @@ import { useTheme } from 'styled-components';
 const styles = {
   EMPHASIZE_OPACITY: '1',
   BASIC_OPACITY: '0.5',
-  EMPHASIZE_STROKE_WIDTH: '0.8px',
+  EMPHASIZE_STROKE_WIDTH: '1.5px',
   BASIC_STROKE_WIDTH: '0.5px',
   EMPHASIZE_STROKE_DASH: 'none',
   BASIC_STROKE_DASH: '1',
@@ -48,15 +48,17 @@ export default function useGraphEmphasize(
           .includes(d.key);
       })
       .style('fill-opacity', styles.EMPHASIZE_OPACITY);
-  }, [hoveredNode, links, nodeSelector, nodes]);
+  }, [hoveredNode, links, nodeSelector, nodes, theme]);
 
   useEffect(() => {
+    if (nodeSelector === null) return;
+
     // click된 노드 강조
     d3.select(nodeSelector)
       .selectAll('text')
       .data(nodes)
       .filter((d) => d.key === selectedKey)
-      .style('fill', theme.COLOR.secondary1);
+      .style('fill', theme.COLOR.secondary2);
 
     // click된 노드의 자식 노드들 강조
     d3.select(nodeSelector)
@@ -69,7 +71,7 @@ export default function useGraphEmphasize(
           .includes(d.key);
         return result;
       })
-      .style('fill', theme.COLOR.secondary1);
+      .style('fill', theme.COLOR.secondary2);
 
     // click/hover된 노드의 링크 강조
     d3.select(linkSelector)

--- a/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
+++ b/frontend/src/pages/PaperDetail/components/PaperInfo.tsx
@@ -121,8 +121,20 @@ const References = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
+  flex: 1;
+  ::-webkit-scrollbar {
+    width: 8px;
+  }
+  ::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: ${({ theme }) => theme.COLOR.black};
+    border-radius: 4px;
+  }
+
   h3 {
     ${({ theme }) => theme.TYPO.body_h};
     padding: 0 15px;


### PR DESCRIPTION
## 개요
그래프 텍스트와 강조되는 링크가 더 잘 보이도록 가시성을 개선했습니다.
스크롤바의 가시성을 개선했습니다.

## 작업사항
- 그래프상의 텍스트에 bold를 적용했습니다.
- 선택된 노드와 자식노드의 텍스트의 색상이 진한노랑(secondary2)로 변경됩니다.
- 강조되는 링크의 두께가 더 굵어졌습니다. (0.8px -> 1.5px)
- 스크롤할 컨텐츠가 있는 경우 스크롤바가 항상 보이게 됩니다.

## 리뷰 요청사항
- N/A

## 실행화면
<img width="407" alt="image" src="https://user-images.githubusercontent.com/30085476/207783774-5344cbe2-a11e-4d4b-9a8b-c99bb830cb17.png">
<img width="259" alt="image" src="https://user-images.githubusercontent.com/30085476/207787142-4d8ebef6-1c4d-45bd-b6c5-4bca38787afc.png">
