### PR TITLE
fix: 최초 렌더링시 중복된 web worker 생성 막기

### DIFF
--- a/frontend/src/pages/PaperDetail/components/ReferenceGraph.tsx
+++ b/frontend/src/pages/PaperDetail/components/ReferenceGraph.tsx
@@ -41,7 +41,7 @@ const ReferenceGraph = ({ data, addChildrensNodes, hoveredNode, changeHoveredNod
   useGraphEmphasize(nodeRef.current, linkRef.current, nodes, links, hoveredNode, data.key);
 
   useEffect(() => {
-    if (!svgRef.current) return;
+    if (!svgRef.current || (nodes.length === 0 && links.length === 0)) return;
 
     if (workerRef.current !== null) {
       workerRef.current.terminate();


### PR DESCRIPTION
## 개요
최초 렌더링시 web worker를 3개씩 생성하는 문제를 해결했습니다.

## 작업사항
- 최초 렌더링시 web worker를 3개씩 생성하는 문제를 해결했습니다.

## 리뷰 요청사항
- N/A
